### PR TITLE
feat: add developer experience APIs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -44,7 +44,15 @@ export default defineConfig({
           { text: 'Typed Events & Factories', link: '/features/typed-events' },
           { text: 'Publisher Confirms', link: '/features/publisher-confirms' },
           { text: 'RPC Support', link: '/features/rpc' },
+          { text: 'Message Size Guard', link: '/features/message-size-guard' },
           { text: 'amqplib Escape Hatch', link: '/features/amqplib-escape-hatch' },
+        ],
+      },
+      {
+        text: 'Developer Experience',
+        items: [
+          { text: 'Middleware', link: '/features/middleware' },
+          { text: 'Headers & Tracing', link: '/features/headers-and-tracing' },
         ],
       },
       {
@@ -78,6 +86,7 @@ export default defineConfig({
           { text: 'Retry + DLQ', link: '/examples/retry-dlq' },
           { text: 'Escape Hatch', link: '/examples/escape-hatch' },
           { text: 'Health + Shutdown', link: '/examples/health-shutdown' },
+          { text: 'Developer Experience', link: '/examples/developer-experience' },
         ],
       },
       {

--- a/docs/api/event-envelope.md
+++ b/docs/api/event-envelope.md
@@ -1,7 +1,8 @@
 # EventEnvelope
 
-`EventEnvelope` is the **canonical message format** used by Rabbit Relay.
-All events published and consumed by the framework conform to this shape.
+`EventEnvelope` is the canonical message format used by Rabbit Relay.
+
+All published and consumed messages use this shape.
 
 ---
 
@@ -9,74 +10,175 @@ All events published and consumed by the framework conform to this shape.
 
 ```ts
 type EventEnvelope<T = unknown> = {
-  id: string;          // unique identifier (used for idempotency & de-duplication)
-  name: string;        // event name (e.g. "scheduler.scheduleTask")
-  version?: string;   // optional semantic version (e.g. "v1")
-  time?: number;      // epoch timestamp (ms)
-  data: T;            // typed payload
-  meta?: EventMeta;   // optional metadata
+  id: string;
+  name: string;
+  v: string;
+  time: number;
+  data: T;
+  meta?: EventMeta;
 };
 
 type EventMeta = {
-  headers?: Record<string, unknown>;
-  corrId?: string;        // correlation id
-  expectsReply?: boolean; // RPC
-  timeoutMs?: number;     // RPC timeout
+  corrId?: string;
+  causationId?: string;
+  headers?: Record<string, string>;
+
+  expectsReply?: boolean;
+  timeoutMs?: number;
 };
 ```
+
+---
+
+## Fields
+
+| Field | Meaning |
+|---|---|
+| `id` | Unique event ID. Useful for idempotency and de-duplication |
+| `name` | Event name, also used as the default routing key |
+| `v` | Event version, for example `v1` |
+| `time` | Event creation time in epoch milliseconds |
+| `data` | Typed payload |
+| `meta` | Optional metadata for headers, tracing, and RPC |
 
 ---
 
 ## Creating envelopes
 
-You normally don’t create envelopes manually.
-Instead, use an **event factory**:
+Use an event factory:
 
 ```ts
-const scheduleTask =
-  event("scheduler.scheduleTask", "v1")
-    .of<{ id: string; when: number }>();
+import { event } from "@bitspacerlabs/rabbit-relay";
 
-const ev = scheduleTask({
-  id: "task-1",
-  when: Date.now(),
+const orderCreated = event("order.created", "v1").of<{
+  orderId: string;
+  amount: number;
+}>();
+
+const ev = orderCreated({
+  orderId: "o-1",
+  amount: 42,
 });
 ```
 
 Factories ensure:
-- correct event name
-- consistent versioning
+
+- consistent envelope shape
+- generated IDs
+- consistent timestamps
 - typed payloads
 
 ---
 
-## Metadata usage
+## Metadata helpers
 
-Metadata is optional and additive.
+Rabbit Relay provides helpers so you do not need to mutate `meta` manually.
+
+### Add headers
+
+```ts
+import { withHeaders } from "@bitspacerlabs/rabbit-relay";
+
+const ev = withHeaders(orderCreated({ orderId: "o-1", amount: 42 }), {
+  tenantId: "tenant-1",
+  source: "orders-service",
+});
+```
+
+### Add metadata
+
+```ts
+import { withMeta } from "@bitspacerlabs/rabbit-relay";
+
+const ev = withMeta(orderCreated({ orderId: "o-1", amount: 42 }), {
+  corrId: "corr-123",
+  headers: {
+    tenantId: "tenant-1",
+  },
+});
+```
+
+### Add correlation or causation
+
+```ts
+import {
+  withCorrelation,
+  withCausation,
+} from "@bitspacerlabs/rabbit-relay";
+
+const ev1 = withCorrelation(orderCreated(data), "corr-123");
+const ev2 = withCausation(orderCreated(data), "parent-event-id");
+```
+
+---
+
+## Tracing child events
+
+Use `traceFrom(parent)` when one event causes another event.
+
+```ts
+import { traceFrom } from "@bitspacerlabs/rabbit-relay";
+
+const child = paymentRequested(
+  {
+    orderId: ev.data.orderId,
+    amount: ev.data.amount,
+  },
+  traceFrom(ev)
+);
+```
+
+This:
+
+- preserves the parent `corrId`
+- uses `parent.id` as `causationId`
+- copies parent headers
+- lets you add extra headers
+
+```ts
+const child = paymentRequested(data, traceFrom(ev, {
+  headers: {
+    source: "payments-service",
+  },
+}));
+```
+
+---
+
+## RPC metadata
+
+RPC is enabled through metadata internally.
+
+You can still do this:
 
 ```ts
 ev.meta = {
-  corrId: "req-123",
-  headers: { source: "scheduler" },
+  expectsReply: true,
+  timeoutMs: 5000,
 };
 ```
 
-Metadata is commonly used for:
-- tracing
-- RPC
-- cross-service correlation
+But the cleaner API is:
+
+```ts
+const reply = await pub.request<Reply>(ev, {
+  timeoutMs: 5000,
+});
+```
 
 ---
 
 ## Notes
 
-- `id` is generated automatically by the factory
-- delivery semantics remain **at-least-once**
-- consumers should be idempotent
+- `EventEnvelope` is plain JSON
+- Delivery remains at-least-once
+- Consumers should be idempotent
+- Keep payloads small and publish references for large data
 
 ---
 
 ## Summary
 
 `EventEnvelope` is the stable contract between publishers and consumers.
-Factories help you create envelopes safely and consistently.
+
+Factories and helpers make it safer to create, enrich, trace, and publish events.

--- a/docs/api/rabbitmq-broker.md
+++ b/docs/api/rabbitmq-broker.md
@@ -2,7 +2,7 @@
 
 `RabbitMQBroker` is the main entry point for publishing and consuming events.
 
-It owns the RabbitMQ connection, topology declaration, publishing, consuming, reconnect behavior, shutdown, and health checks.
+It owns RabbitMQ connection handling, topology declaration, publishing, consuming, reconnect behavior, shutdown, and health checks.
 
 ---
 
@@ -13,6 +13,17 @@ const broker = new RabbitMQBroker("payments_service");
 ```
 
 The peer name identifies this broker in Rabbit Relay health output.
+
+You can also set broker-level defaults:
+
+```ts
+const broker = new RabbitMQBroker("orders_service", {
+  exchangeType: "topic",
+  durable: true,
+  publisherConfirms: true,
+  maxMessageBytes: 256 * 1024,
+});
+```
 
 ---
 
@@ -45,6 +56,7 @@ This:
   publisherConfirms?: boolean;
   passiveQueue?: boolean;
   queueArgs?: Record<string, unknown>;
+  maxMessageBytes?: number;
   deadLetter?: DeadLetterConfig;
   amqp?: {
     exchange?: Options.AssertExchange;
@@ -81,10 +93,11 @@ For normal publishing:
 await pub.produce(eventEnvelope);
 ```
 
-For per-message AMQP options:
+For per-message options:
 
 ```ts
 await pub.publish(eventEnvelope, {
+  maxMessageBytes: 64 * 1024,
   amqp: {
     publish: {
       persistent: true,
@@ -103,6 +116,33 @@ await api.orderCreated({ id: "o-1" });
 
 ---
 
+## Typed RPC request
+
+Use `request<TReply>()` for request/reply flows.
+
+```ts
+type ChargeReply = {
+  ok: boolean;
+  transactionId?: string;
+};
+
+const reply = await pub.request<ChargeReply>(
+  charge({
+    orderId: "o-1",
+    amount: 42,
+  }),
+  {
+    timeoutMs: 5000,
+  }
+);
+```
+
+This is the clean API for RPC.
+
+The old `meta.expectsReply` style still works for backward compatibility.
+
+---
+
 ## Consuming
 
 ```ts
@@ -113,13 +153,26 @@ sub.handle("orderCreated", async (_id, ev) => {
 await sub.consume({
   prefetch: 50,
   concurrency: 10,
-  onError: "retry",
-  retry: {
-    attempts: 3,
-    then: "dead-letter",
-  },
 });
 ```
+
+---
+
+## Local middleware
+
+Use middleware for local, queue-specific processing behavior.
+
+```ts
+sub.use(async (ctx, next) => {
+  console.log("before", ctx.event.name);
+  await next();
+  console.log("after", ctx.event.name);
+});
+```
+
+Middleware wraps the handler for this broker interface only.
+
+It is different from plugins, which are process-global.
 
 ---
 
@@ -135,11 +188,32 @@ type ConsumeOptions = {
     attempts: number;
     then?: "ack" | "requeue" | "dead-letter";
   };
+  dedupe?: Dedupe | {
+    enabled?: boolean;
+    ttlMs?: number;
+    maxKeys?: number;
+    keyOf?: (event: unknown) => string | undefined;
+  };
   amqp?: {
     consume?: Options.Consume;
   };
 };
 ```
+
+---
+
+## Dedupe option
+
+```ts
+await sub.consume({
+  dedupe: {
+    enabled: true,
+    ttlMs: 60_000,
+  },
+});
+```
+
+Duplicate messages are acknowledged and skipped before reaching the handler.
 
 ---
 
@@ -180,8 +254,6 @@ Health includes:
 ```ts
 await broker.close();
 ```
-
-This stops active consumers and closes RabbitMQ resources.
 
 Use it during process shutdown:
 

--- a/docs/examples/developer-experience.md
+++ b/docs/examples/developer-experience.md
@@ -1,0 +1,16 @@
+# Developer Experience
+
+This example demonstrates the Phase 2 developer experience APIs in one small flow.
+
+It shows:
+
+- typed RPC with `request<TReply>()`
+- metadata helpers with `withHeaders()`
+- trace propagation with `traceFrom()`
+- local middleware with `use()`
+- consumer-side de-duplication with `consume({ dedupe })`
+- message size guard with `maxMessageBytes`
+- typed `MessageTooLargeError`
+
+Full example on GitHub:  
+https://github.com/bitspacerlabs/rabbit-relay/tree/main/examples/09-developer-experience

--- a/docs/features/headers-and-tracing.md
+++ b/docs/features/headers-and-tracing.md
@@ -1,0 +1,175 @@
+# Headers & Tracing
+
+Rabbit Relay provides small helpers for adding metadata, headers, correlation IDs, and causation IDs to events.
+
+These helpers keep event code clean and avoid repetitive manual `meta` mutation.
+
+---
+
+## Why metadata matters
+
+In event-driven systems, a single business action often creates multiple events.
+
+Example:
+
+```text
+order.created
+  -> payment.requested
+  -> payment.processed
+  -> shipping.started
+```
+
+To debug this flow, events should share a correlation ID.
+
+Each child event should also point to the event that caused it.
+
+---
+
+## Event metadata
+
+Rabbit Relay event metadata supports:
+
+```ts
+type EventMeta = {
+  corrId?: string;
+  causationId?: string;
+  headers?: Record<string, string>;
+  expectsReply?: boolean;
+  timeoutMs?: number;
+};
+```
+
+---
+
+## Add headers
+
+```ts
+import { withHeaders } from "@bitspacerlabs/rabbit-relay";
+
+const ev = withHeaders(orderCreated(data), {
+  tenantId: "tenant-1",
+  source: "orders-service",
+});
+```
+
+Headers are also copied into AMQP publish headers.
+
+---
+
+## Add metadata
+
+```ts
+import { withMeta } from "@bitspacerlabs/rabbit-relay";
+
+const ev = withMeta(orderCreated(data), {
+  corrId: "corr-123",
+  headers: {
+    tenantId: "tenant-1",
+  },
+});
+```
+
+`withMeta()` preserves existing metadata and merges headers.
+
+---
+
+## Correlation and causation helpers
+
+```ts
+import {
+  withCorrelation,
+  withCausation,
+} from "@bitspacerlabs/rabbit-relay";
+
+const ev = withCorrelation(orderCreated(data), "corr-123");
+
+const child = withCausation(paymentRequested(data), ev.id);
+```
+
+---
+
+## Trace from parent event
+
+Use `traceFrom()` when creating a child event from a parent event.
+
+```ts
+import { traceFrom } from "@bitspacerlabs/rabbit-relay";
+
+sub.handle("order.created", async (_id, ev) => {
+  await pub.produce(
+    paymentRequested(
+      {
+        orderId: ev.data.orderId,
+        amount: ev.data.amount,
+      },
+      traceFrom(ev)
+    )
+  );
+});
+```
+
+`traceFrom(parent)`:
+
+- preserves `parent.meta.corrId` if present
+- otherwise uses `parent.id` as the correlation ID
+- sets `causationId` to `parent.id`
+- copies parent headers
+
+---
+
+## Add extra metadata while tracing
+
+```ts
+const child = paymentRequested(
+  data,
+  traceFrom(parent, {
+    headers: {
+      source: "payments-service",
+    },
+  })
+);
+```
+
+Parent headers and child headers are merged.
+
+---
+
+## Recommended usage
+
+At the start of a flow:
+
+```ts
+const ev = withCorrelation(
+  withHeaders(orderCreated(data), {
+    tenantId: "tenant-1",
+    source: "orders-service",
+  }),
+  "corr-123"
+);
+```
+
+Inside consumers:
+
+```ts
+const next = paymentRequested(data, traceFrom(ev));
+```
+
+---
+
+## Relationship with plugins
+
+Plugins are still useful for process-wide tracing behavior.
+
+Helpers are useful when you want explicit metadata in application code.
+
+They work well together.
+
+---
+
+## Summary
+
+- Use `withHeaders()` for application headers
+- Use `withMeta()` for full metadata control
+- Use `withCorrelation()` for root correlation
+- Use `traceFrom()` for child events
+- Correlation and causation make event chains easier to debug

--- a/docs/features/message-size-guard.md
+++ b/docs/features/message-size-guard.md
@@ -1,0 +1,143 @@
+# Message Size Guard
+
+Rabbit Relay can protect publishers from accidentally sending oversized messages.
+
+Large messages can hurt RabbitMQ performance and make systems harder to operate.
+
+The message size guard checks the serialized event size before publishing.
+
+---
+
+## Why this exists
+
+RabbitMQ works best with reasonably small messages.
+
+Instead of publishing large payloads, prefer:
+
+- storing large data in object storage
+- publishing a file/object reference
+- letting consumers fetch the large data when needed
+
+---
+
+## Broker-level default
+
+Set a default max size on the broker:
+
+```ts
+const broker = new RabbitMQBroker("orders-service", {
+  maxMessageBytes: 256 * 1024,
+});
+```
+
+This applies to publishers created by this broker unless overridden.
+
+---
+
+## Exchange-level setting
+
+```ts
+const pub = await broker
+  .queue("orders.q")
+  .exchange("orders.ex", {
+    exchangeType: "topic",
+    maxMessageBytes: 128 * 1024,
+  });
+```
+
+---
+
+## Per-message override
+
+Use `publish()` when you need a per-message size limit.
+
+```ts
+await pub.publish(orderCreated(data), {
+  maxMessageBytes: 64 * 1024,
+});
+```
+
+`request()` also supports the same option:
+
+```ts
+const reply = await pub.request<Reply>(requestEvent, {
+  timeoutMs: 5000,
+  maxMessageBytes: 64 * 1024,
+});
+```
+
+---
+
+## Error type
+
+If the serialized event is too large, Rabbit Relay throws `MessageTooLargeError`.
+
+```ts
+import { MessageTooLargeError } from "@bitspacerlabs/rabbit-relay";
+
+try {
+  await pub.publish(bigEvent, {
+    maxMessageBytes: 8 * 1024,
+  });
+} catch (err) {
+  if (err instanceof MessageTooLargeError) {
+    console.error("Message too large:", {
+      eventName: err.eventName,
+      sizeBytes: err.sizeBytes,
+      maxBytes: err.maxBytes,
+    });
+  }
+}
+```
+
+---
+
+## Precedence
+
+Message size is resolved in this order:
+
+```text
+per-message option
+exchange option
+broker default
+```
+
+If none is set, Rabbit Relay does not enforce a max size.
+
+---
+
+## What is counted
+
+Rabbit Relay checks the size of:
+
+```ts
+Buffer.from(JSON.stringify(eventEnvelope))
+```
+
+That means the full event envelope is counted, including:
+
+- `id`
+- `name`
+- `v`
+- `time`
+- `data`
+- `meta`
+
+---
+
+## Best practices
+
+- Keep event payloads small
+- Publish IDs and references instead of large blobs
+- Store large payloads externally
+- Set conservative limits for critical services
+- Treat size errors as developer feedback
+
+---
+
+## Summary
+
+- `maxMessageBytes` prevents oversized publishes
+- works at broker, exchange, and per-message level
+- throws a typed `MessageTooLargeError`
+- encourages healthier RabbitMQ usage

--- a/docs/features/middleware.md
+++ b/docs/features/middleware.md
@@ -1,0 +1,191 @@
+# Middleware
+
+Middleware lets you add local behavior around consumer handlers.
+
+Unlike plugins, middleware is attached to one broker interface and affects only that queue/exchange flow.
+
+---
+
+## Why middleware exists
+
+Plugins are process-global.
+
+That is useful for shared behavior like logging, tracing, and metrics.
+
+Middleware is local.
+
+Use middleware when a specific consumer needs behavior such as:
+
+- local logging
+- tenant checks
+- validation
+- timing
+- custom tracing
+- lightweight authorization
+- per-consumer guards
+
+---
+
+## Basic usage
+
+```ts
+sub.use(async (ctx, next) => {
+  console.log("before", ctx.event.name);
+
+  await next();
+
+  console.log("after", ctx.event.name);
+});
+
+sub.handle("order.created", async (_id, ev) => {
+  console.log("order:", ev.data);
+});
+
+await sub.consume();
+```
+
+---
+
+## Middleware context
+
+```ts
+type ConsumeMiddlewareContext = {
+  id: string | number;
+  event: EventEnvelope;
+  queue: string;
+};
+```
+
+| Field | Meaning |
+|---|---|
+| `id` | RabbitMQ delivery tag |
+| `event` | Parsed Rabbit Relay event envelope |
+| `queue` | Queue currently consuming the message |
+
+---
+
+## Execution order
+
+Middleware wraps the handler:
+
+```text
+plugin beforeProcess
+  middleware 1 before
+    middleware 2 before
+      handler
+    middleware 2 after
+  middleware 1 after
+plugin afterProcess
+ack
+```
+
+If middleware throws, Rabbit Relay treats it like a handler error.
+
+The configured error policy applies:
+
+```ts
+await sub.consume({
+  onError: "retry",
+  retry: {
+    attempts: 3,
+    then: "dead-letter",
+  },
+});
+```
+
+---
+
+## Multiple middleware
+
+Middleware runs in registration order.
+
+```ts
+sub.use(async (ctx, next) => {
+  console.log("first before");
+  await next();
+  console.log("first after");
+});
+
+sub.use(async (ctx, next) => {
+  console.log("second before");
+  await next();
+  console.log("second after");
+});
+```
+
+Output:
+
+```text
+first before
+second before
+handler
+second after
+first after
+```
+
+---
+
+## Local validation example
+
+```ts
+sub.use(async (ctx, next) => {
+  const tenantId = ctx.event.meta?.headers?.tenantId;
+
+  if (!tenantId) {
+    throw new Error("Missing tenantId");
+  }
+
+  await next();
+});
+```
+
+---
+
+## Timing example
+
+```ts
+sub.use(async (ctx, next) => {
+  const start = Date.now();
+
+  try {
+    await next();
+  } finally {
+    console.log(`${ctx.event.name} took ${Date.now() - start}ms`);
+  }
+});
+```
+
+---
+
+## Middleware vs plugins
+
+| Feature | Middleware | Plugins |
+|---|---|---|
+| Scope | Local to broker interface | Process-wide |
+| Registration | `sub.use(...)` | `pluginManager.register(...)` |
+| Wraps handler | Yes | Hooks around lifecycle |
+| Best for | Consumer-specific behavior | Shared platform behavior |
+
+---
+
+## What middleware does not expose yet
+
+The first middleware API intentionally does not expose:
+
+- raw RabbitMQ message
+- channel
+- manual ack/nack
+
+This avoids double-ack bugs and keeps the API safe.
+
+Advanced middleware can be added later if needed.
+
+---
+
+## Summary
+
+- Middleware is local and explicit
+- Use it for consumer-specific behavior
+- It wraps handler execution
+- Errors follow normal retry/DLQ behavior
+- Plugins remain the better fit for process-wide concerns

--- a/docs/features/rpc.md
+++ b/docs/features/rpc.md
@@ -1,74 +1,137 @@
 # RPC (Request–Reply)
 
-Rabbit Relay supports a **request–reply (RPC) pattern** on top of RabbitMQ.
+Rabbit Relay supports a request–reply pattern on top of RabbitMQ.
 
-RPC allows a publisher to **send a request and wait for a single reply** from a consumer, using standard AMQP semantics (`replyTo`, `correlationId`, timeouts).
+RPC allows a publisher to send a request and wait for a single reply from a consumer, using standard AMQP semantics: `replyTo`, `correlationId`, and timeouts.
 
-RPC is **opt-in per message** and does not affect normal fire-and-forget events.
+RPC is opt-in per message and does not affect normal fire-and-forget events.
 
 ---
 
 ## When to use RPC
 
-Use RPC only when a workflow **requires a synchronous response**.
+Use RPC only when a workflow requires a direct response.
 
-If a workflow can be modeled as **events**, prefer events.
+Good examples:
+
+- validate a payment
+- check inventory
+- request a calculated value
+- ask another internal service for a decision
+
+If a workflow can be modeled as events, prefer events.
+
 RPC introduces tighter coupling and should be used deliberately.
 
 ---
 
-## Making an RPC request
+## Typed request API
 
-Any event can become an RPC request by setting metadata on its envelope.
+The recommended API is `request<TReply>()`.
 
 ```ts
-const req = makePriceLookup({ sku: "SKU-1" });
+type ChargeReply = {
+  ok: boolean;
+  transactionId?: string;
+  reason?: string;
+};
+
+const reply = await pub.request<ChargeReply>(
+  charge({
+    orderId: "o-1",
+    amount: 42,
+    currency: "USD",
+  }),
+  {
+    timeoutMs: 5000,
+  }
+);
+```
+
+This is cleaner than manually setting RPC metadata.
+
+---
+
+## Request options
+
+`request()` accepts the same per-message publish options as `publish()`, plus `timeoutMs`.
+
+```ts
+const reply = await pub.request<ChargeReply>(
+  charge(payload),
+  {
+    timeoutMs: 5000,
+    routingKey: "payments.charge",
+    maxMessageBytes: 64 * 1024,
+    amqp: {
+      publish: {
+        persistent: true,
+      },
+    },
+  }
+);
+```
+
+---
+
+## Handling an RPC request
+
+On the consumer side, the handler return value becomes the reply.
+
+```ts
+sub.handle("payments.charge", async (_id, ev) => {
+  if (ev.data.amount <= 0) {
+    return {
+      ok: false,
+      reason: "invalid amount",
+    };
+  }
+
+  return {
+    ok: true,
+    transactionId: "txn_123",
+  };
+});
+```
+
+Consumers do not need special RPC code.
+
+If the message has `replyTo`, Rabbit Relay sends the return value back.
+
+---
+
+## Backward compatibility
+
+The old metadata-based RPC style still works.
+
+```ts
+const req = charge(payload);
 
 req.meta = {
   expectsReply: true,
   timeoutMs: 5000,
 };
-```
 
-Publishing the event now **returns a promise that resolves with the reply**:
-
-```ts
 const reply = await pub.produce(req);
 ```
 
-- If a reply arrives → the promise resolves
-- If no reply arrives before `timeoutMs` → the promise rejects
-- If the responder throws → the promise resolves with `null`
-
----
-
-## Handling an RPC request (consumer)
-
-On the consumer side, **the handler return value becomes the reply**.
-
-```ts
-sub.handle("price.lookup", async (_id, ev) => {
-  return { price: 42 };
-});
-```
-
-If the handler:
-- returns a value → it is sent back as the reply
-- throws an error → a reply is still sent, with `null`
-
-Consumers **do not need to know** whether a message is RPC or not.
+Use `request<TReply>()` for new code.
 
 ---
 
 ## Timeouts and errors
 
-- Default timeout: **5000 ms**
-- Timeouts throw on the caller side
-- Handler errors do **not** throw on the caller side — they return `null`
+- Default timeout: `5000 ms`
+- Timeouts reject on the caller side
+- Handler errors return `null` as the reply
+- Publish failures reject
 
 ```ts
 try {
-  const reply = await pub.produce(req);
+  const reply = await pub.request<Reply>(req, {
+    timeoutMs: 5000,
+  });
+
   if (reply === null) {
     // responder failed
   }
@@ -79,40 +142,46 @@ try {
 
 ---
 
-## What Rabbit Relay manages for you
+## What Rabbit Relay manages
 
-When `meta.expectsReply = true`, Rabbit Relay automatically:
+For each RPC request, Rabbit Relay:
 
-- creates a temporary, exclusive reply queue
-- sets `replyTo` and `correlationId`
+- creates a temporary exclusive reply queue
+- sets `replyTo`
+- sets `correlationId`
 - matches replies to requests
-- enforces the timeout
-- cleans up resources
+- enforces timeout
+- cleans up the reply queue
 
 ---
 
-## What RPC does *not* guarantee
+## What RPC does not guarantee
 
-RPC does **not** provide:
+RPC does not provide:
+
 - exactly-once delivery
+- cancellation of in-flight work after timeout
 - transactional semantics across services
 - consumer-side success guarantees
+
+If a requester times out, the responder may still process the message later.
 
 ---
 
 ## Best practices
 
-- Prefer events over RPC where possible
-- Use RPC for **queries**, not workflows
+- Prefer events for workflows
+- Use RPC for short internal decisions or queries
+- Keep replies small
+- Keep timeouts short
+- Make RPC handlers idempotent
 - Avoid long-running handlers
-- Keep replies small and bounded
 
 ---
 
 ## Summary
 
-- RPC is opt-in per message
-- Enabled via `meta.expectsReply`
+- Use `request<TReply>()` for new RPC flows
 - Handler return value becomes the reply
 - Timeouts and failures are explicit
-- Built on standard RabbitMQ semantics
+- Built on normal RabbitMQ semantics

--- a/docs/features/ttl-dedupe.md
+++ b/docs/features/ttl-dedupe.md
@@ -1,106 +1,142 @@
 # TTL De‑duplication
 
-TTL de‑duplication is a **consumer-side safeguard** that helps suppress duplicate messages
-within a short time window, while keeping **at‑least‑once delivery** semantics.
+TTL de‑duplication is a consumer-side safeguard that helps suppress duplicate messages within a short time window, while keeping at-least-once delivery semantics.
 
-Rabbit Relay provides a small **in-memory helper** for this purpose.
-It is optional and intentionally simple.
+Rabbit Relay supports de-duplication in two ways:
 
----
-
-## What it does
-
-TTL de‑duplication remembers message IDs for a limited time (TTL).
-
-If the same ID is seen again within that window:
-- the message is considered a duplicate
-- your handler can safely skip processing
-
-This is a **best‑effort optimization**, not a delivery guarantee.
+1. `consume({ dedupe })` — recommended for most consumers
+2. `makeMemoryDedupe()` — lower-level helper for manual control
 
 ---
 
-## When to use it
+## Recommended usage
 
-Use TTL de‑duplication when:
-- retries or reconnects may deliver the same message again
-- occasional duplicates are expected
-- you want a lightweight guard without external storage
+Use the `dedupe` consume option:
 
-Do **not** rely on it as your only correctness mechanism.
-Handlers should still be idempotent when possible.
+```ts
+await sub.consume({
+  prefetch: 10,
+  concurrency: 5,
+  dedupe: {
+    enabled: true,
+    ttlMs: 60_000,
+    maxKeys: 100_000,
+  },
+});
+```
+
+When a duplicate message is detected:
+
+- the message is acknowledged
+- the handler is skipped
+- retry/DLQ behavior is not triggered
+
+A duplicate is not treated as a processing failure.
 
 ---
 
-## Basic usage
+## Custom dedupe key
+
+By default, Rabbit Relay uses the event envelope ID.
+
+You can customize the key:
+
+```ts
+await sub.consume({
+  dedupe: {
+    enabled: true,
+    keyOf: (ev) => ev.data.orderId,
+    ttlMs: 5 * 60_000,
+  },
+});
+```
+
+This treats repeated messages for the same order ID as duplicates within the TTL window.
+
+---
+
+## Disable dedupe
+
+```ts
+await sub.consume({
+  dedupe: {
+    enabled: false,
+  },
+});
+```
+
+Or simply omit `dedupe`.
+
+---
+
+## Using a dedupe instance
+
+You can still create and pass your own dedupe instance.
 
 ```ts
 import { makeMemoryDedupe } from "@bitspacerlabs/rabbit-relay";
 
 const dedupe = makeMemoryDedupe({
-  ttlMs: 5 * 60_000, // remember IDs for 5 minutes
+  ttlMs: 60_000,
 });
-```
 
-Use it inside a consumer handler:
-
-```ts
-sub.handle("orderCreated", async (_id, ev) => {
-  if (!dedupe.checkAndRemember(ev)) {
-    // duplicate within TTL → skip
-    return;
-  }
-
-  // safe to process
-  console.log("Process order", ev.data.id);
+await sub.consume({
+  dedupe,
 });
 ```
 
 ---
 
-## How duplicates are detected
+## Manual helper usage
 
-By default, the helper uses the **event envelope ID**.
-
-You can customize what “duplicate” means by providing a custom key extractor:
+For advanced cases, use the helper directly.
 
 ```ts
 const dedupe = makeMemoryDedupe({
-  keyOf: (e) => e.data.orderId, // domain-level id
+  ttlMs: 5 * 60_000,
+});
+
+sub.handle("order.created", async (_id, ev) => {
+  if (!dedupe.checkAndRemember(ev)) {
+    return;
+  }
+
+  console.log("Process order", ev.data.orderId);
 });
 ```
-
-This treats repeated events for the same order as duplicates within the TTL window.
 
 ---
 
 ## Important limitations
 
-TTL de‑duplication is **in-memory**:
+The built-in dedupe is in-memory:
 
 - duplicates across process restarts are not detected
 - duplicates across multiple instances are not shared
-- memory is bounded by a soft max size
+- memory is bounded by TTL and `maxKeys`
 
-For cross-instance or long-lived guarantees, use:
-- idempotent database writes
-- Redis / external stores
-- application-level keys
+For stronger guarantees, use:
+
+- database unique constraints
+- Redis or another shared store
+- idempotent writes
+- transactional outbox patterns
 
 ---
 
 ## Best practices
 
-- Keep TTL short (minutes, not hours)
-- Choose a stable key (envelope ID or domain ID)
-- Combine with publisher confirms for better protection
-- Treat de‑duplication as a guard, not a guarantee
+- Keep TTL short
+- Use a stable key
+- Prefer envelope ID for transport-level duplicates
+- Use domain ID for business-level duplicates
+- Do not rely on in-memory dedupe as your only correctness mechanism
 
 ---
 
 ## Summary
 
-- TTL de‑duplication suppresses repeated messages within a short window
-- It is consumer-side and optional
-- It does not replace idempotent handlers
-- Simple, explicit, and easy to reason about
+- `consume({ dedupe })` is the recommended API
+- duplicates are acknowledged and skipped
+- the built-in helper is process-local and in-memory
+- handlers should still be idempotent

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,42 +1,38 @@
 # Configuration
 
-Rabbit Relay uses **sensible defaults** and a small set of configuration options.
+Rabbit Relay uses sensible defaults and a small set of configuration options.
+
 Most applications only need to set a broker URL and then tune publishing and consuming per use case.
 
 ---
 
 ## Environment variables
 
-Rabbit Relay reads configuration from environment variables at runtime.
-
 ### `RABBITMQ_URL`
 
-The RabbitMQ connection URL.
-
-- **Default:** `amqp://user:password@localhost`
-- Used by all publishers and consumers unless overridden
+RabbitMQ connection URL.
 
 ```bash
 export RABBITMQ_URL=amqp://user:password@localhost
+```
+
+Default:
+
+```text
+amqp://user:password@localhost
 ```
 
 ---
 
 ### `AMQP_CONN_NAME`
 
-Optional human-readable connection name shown in the RabbitMQ Management UI.
-
-This is useful when:
-
-- running multiple services
-- debugging connections
-- inspecting clients in production
+Optional human-readable connection name shown in RabbitMQ Management UI.
 
 ```bash
-export AMQP_CONN_NAME=app:dev
+export AMQP_CONN_NAME=app:orders-service
 ```
 
-If not set, Rabbit Relay generates a connection name from the Node.js process and hostname.
+If not set, Rabbit Relay generates a name from the process title, hostname, and process ID.
 
 ---
 
@@ -49,10 +45,11 @@ const broker = new RabbitMQBroker("orders-service", {
   exchangeType: "topic",
   durable: true,
   publisherConfirms: false,
+  maxMessageBytes: 256 * 1024,
 });
 ```
 
-These defaults can be overridden when declaring an exchange.
+These defaults can be overridden when declaring an exchange or publishing a message.
 
 ---
 
@@ -78,14 +75,13 @@ Common options:
 | `publisherConfirms` | Whether publishes wait for broker confirmation |
 | `passiveQueue` | Check queue exists instead of declaring it |
 | `queueArgs` | RabbitMQ queue arguments |
+| `maxMessageBytes` | Maximum serialized event size |
 | `deadLetter` | Built-in DLQ helper |
 | `amqp` | Native `amqplib` passthrough options |
 
 ---
 
-## Performance tuning
-
-Rabbit Relay exposes two main consumer controls: `prefetch` and `concurrency`.
+## Consumer tuning
 
 ```ts
 await sub.consume({
@@ -96,49 +92,38 @@ await sub.consume({
 
 ### `prefetch`
 
-Maximum number of **unacknowledged messages** RabbitMQ can deliver to this consumer.
-
-- Controls RabbitMQ delivery pressure
-- Prevents unlimited unacked messages
-- Lower values are safer
-- Higher values may improve throughput
+Maximum number of unacknowledged messages RabbitMQ can deliver.
 
 ### `concurrency`
 
-Maximum number of handlers Rabbit Relay runs **in parallel**.
+Maximum number of handlers Rabbit Relay runs in parallel.
 
-- Defaults to `prefetch`
-- Should usually be less than or equal to `prefetch`
-- Protects database pools, APIs, CPU, and memory
+Use both together to protect:
+
+- database pools
+- APIs
+- CPU
+- memory
 
 ---
 
-## Publisher confirms
-
-Enable RabbitMQ **publisher confirms** when your application must know that RabbitMQ accepted the message.
+## Consumer de-duplication
 
 ```ts
-const pub = await broker
-  .queue("orders.publisher.q")
-  .exchange("orders.ex", {
-    exchangeType: "topic",
-    publisherConfirms: true,
-  });
+await sub.consume({
+  dedupe: {
+    enabled: true,
+    ttlMs: 60_000,
+    maxKeys: 100_000,
+  },
+});
 ```
 
-With confirms enabled:
-
-- Rabbit Relay publishes through a confirm channel
-- publish calls wait for broker acknowledgement
-- failures are surfaced to the caller
-
-Use this for critical event boundaries.
+Duplicate messages are acknowledged and skipped.
 
 ---
 
 ## Error handling policy
-
-Error behavior is configured when starting a consumer.
 
 ```ts
 await sub.consume({
@@ -146,28 +131,12 @@ await sub.consume({
 });
 ```
 
-### `ack`
-
-Default. Errors are logged and the message is acknowledged.
-
-### `requeue`
-
-The message is negatively acknowledged and requeued.
-
-Use carefully because this can create infinite retry loops.
-
-### `dead-letter`
-
-The message is negatively acknowledged with `requeue=false`.
-
-RabbitMQ routes it to a DLQ if the queue has dead-letter configuration.
-
-### `retry`
-
-Rabbit Relay republishes the message for a bounded number of attempts.
+Recommended production pattern:
 
 ```ts
 await sub.consume({
+  prefetch: 20,
+  concurrency: 5,
   onError: "retry",
   retry: {
     attempts: 3,
@@ -179,8 +148,6 @@ await sub.consume({
 ---
 
 ## Dead-letter queues
-
-Rabbit Relay can configure dead-letter routing for a queue.
 
 ```ts
 const sub = await broker
@@ -197,15 +164,29 @@ const sub = await broker
   });
 ```
 
-With `autoDeclare: true`, Rabbit Relay declares the DLX, DLQ, and binding.
+---
 
-If your infrastructure manages RabbitMQ topology, omit `autoDeclare` and create DLQ resources externally.
+## Message size guard
+
+Set a max serialized message size:
+
+```ts
+const broker = new RabbitMQBroker("orders-service", {
+  maxMessageBytes: 256 * 1024,
+});
+```
+
+Override per publish:
+
+```ts
+await pub.publish(orderCreated(data), {
+  maxMessageBytes: 64 * 1024,
+});
+```
 
 ---
 
 ## Native amqplib passthrough
-
-Rabbit Relay does not block native RabbitMQ features.
 
 ```ts
 await broker
@@ -228,19 +209,13 @@ await broker
   });
 ```
 
-Use this for advanced queue, exchange, binding, publish, or consume options.
-
 ---
 
 ## Health and shutdown
 
-Use `health()` for operational checks.
-
 ```ts
 const health = await broker.health();
 ```
-
-Use `close()` during shutdown.
 
 ```ts
 process.on("SIGTERM", async () => {
@@ -253,9 +228,10 @@ process.on("SIGTERM", async () => {
 
 ## Notes and best practices
 
-- RabbitMQ bindings are persistent; changing routing keys does not remove old bindings
-- Queue arguments are immutable; changing DLQ or quorum settings may require queue recreation
+- RabbitMQ bindings are persistent
+- Queue arguments are immutable
 - Tune `prefetch` and `concurrency` together
 - Use retries with DLQs instead of infinite requeue loops
 - Enable `publisherConfirms` for critical event boundaries
-- Keep handlers idempotent because RabbitMQ delivery is at-least-once
+- Keep handlers idempotent
+- Keep messages small

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-This guide walks you through publishing and consuming your **first typed event** using **Rabbit Relay**.
+This guide walks you through publishing and consuming your first typed event using Rabbit Relay.
 
 ---
 
@@ -13,9 +13,6 @@ npm install @bitspacerlabs/rabbit-relay
 ---
 
 ## Define an event contract
-
-This file defines **event names and payloads only**.
-It contains **no RabbitMQ logic** and can be shared across services.
 
 ```ts
 // events.ts
@@ -35,16 +32,23 @@ export type ScheduleTaskData = {
 ## Publish
 
 ```ts
-import { RabbitMQBroker, event } from "@bitspacerlabs/rabbit-relay";
+import {
+  RabbitMQBroker,
+  event,
+  withHeaders,
+} from "@bitspacerlabs/rabbit-relay";
 import { SchedulerEvents, type ScheduleTaskData } from "./events";
 
 (async () => {
-  const broker = new RabbitMQBroker("scheduler_service");
+  const broker = new RabbitMQBroker("scheduler_service", {
+    maxMessageBytes: 256 * 1024,
+  });
 
   const pub = await broker
     .queue("scheduler_publish_queue")
     .exchange("scheduler_exchange", {
       exchangeType: "topic",
+      publisherConfirms: true,
     });
 
   const scheduleTask = event(
@@ -53,10 +57,15 @@ import { SchedulerEvents, type ScheduleTaskData } from "./events";
   ).of<ScheduleTaskData>();
 
   await pub.produce(
-    scheduleTask({
-      id: "task-1",
-      when: Date.now() + 5000,
-    })
+    withHeaders(
+      scheduleTask({
+        id: "task-1",
+        when: Date.now() + 5000,
+      }),
+      {
+        source: "scheduler_service",
+      }
+    )
   );
 
   await broker.close();
@@ -83,7 +92,11 @@ await api.scheduleTask({
 ## Consume
 
 ```ts
-import { RabbitMQBroker, type EventEnvelope } from "@bitspacerlabs/rabbit-relay";
+import {
+  RabbitMQBroker,
+  traceFrom,
+  type EventEnvelope,
+} from "@bitspacerlabs/rabbit-relay";
 import { SchedulerEvents, type ScheduleTaskData } from "./events";
 
 (async () => {
@@ -98,13 +111,23 @@ import { SchedulerEvents, type ScheduleTaskData } from "./events";
       routingKey: "scheduler.*",
     });
 
+  sub.use(async (ctx, next) => {
+    console.log("processing", ctx.event.name);
+    await next();
+  });
+
   sub.handle(SchedulerEvents.ScheduleTask, async (_id, ev) => {
     console.log("Task received:", ev.data);
+    console.log("Trace metadata for child event:", traceFrom(ev));
   });
 
   await sub.consume({
     prefetch: 10,
     concurrency: 5,
+    dedupe: {
+      enabled: true,
+      ttlMs: 60_000,
+    },
   });
 })();
 ```
@@ -148,12 +171,35 @@ await sub.consume({
 
 ---
 
+## Typed RPC
+
+Use `request<TReply>()` for request/reply flows.
+
+```ts
+type Reply = {
+  ok: boolean;
+};
+
+const reply = await pub.request<Reply>(
+  scheduleTask({
+    id: "task-rpc",
+    when: Date.now(),
+  }),
+  {
+    timeoutMs: 5000,
+  }
+);
+```
+
+---
+
 ## Publish with native AMQP options
 
 Use `publish()` when you need per-message RabbitMQ options.
 
 ```ts
 await pub.publish(scheduleTask({ id: "task-3", when: Date.now() }), {
+  maxMessageBytes: 64 * 1024,
   amqp: {
     publish: {
       persistent: true,
@@ -187,10 +233,11 @@ process.on("SIGTERM", async () => {
 
 ## Summary
 
-- Contracts define event names and payloads
 - Publishers create typed event envelopes
 - Consumers explicitly declare what they handle
-- `prefetch` controls RabbitMQ delivery pressure
-- `concurrency` controls parallel handler execution
-- Retry + DLQ gives safer production failure handling
-- Native `amqplib` options remain available when needed
+- `request<TReply>()` supports typed RPC
+- `withHeaders()` and `traceFrom()` help with metadata
+- middleware is local to a consumer flow
+- `consume({ dedupe })` skips duplicate messages
+- retry + DLQ gives safer production failure handling
+- native `amqplib` options remain available when needed

--- a/examples/01-confirms/dedupe/README.md
+++ b/examples/01-confirms/dedupe/README.md
@@ -1,58 +1,47 @@
 # Consumer De-duplication – Basics
 
-**What it shows:** a consumer that drops duplicate deliveries of the same logical event using an **in-memory, TTL-based de-duplication window**.
-
-This demonstrates how to safely handle **at-least-once delivery** without doing work twice.
+**What it shows:** consumer-side de-duplication using the Phase 2 `consume({ dedupe })` option.
 
 ---
 
-**Files**
-
-- `consumer.dedupe.ts` – consumes events and drops duplicates by event ID
-- `publisher.dupes.ts` – intentionally publishes the *same event ID twice*
-- `publisher.loop.ts` *(optional)* – publishes unique events for comparison
-
----
-
-**Run**
+## Run
 
 ```bash
-# terminal 1 – start the de-dupe consumer
+# terminal 1
 npx ts-node-dev --transpile-only examples/01-confirms/dedupe/consumer.dedupe.ts
 
-# terminal 2 – publish duplicate pairs (same id twice)
+# terminal 2
 npx ts-node-dev --transpile-only examples/01-confirms/dedupe/publisher.dupes.ts
-
-# optional terminal 3 – publish normal unique events
-npx ts-node-dev --transpile-only examples/01-confirms/dedupe/publisher.loop.ts
 ```
 
 ---
 
-**Expect**
+## Expect
 
-- the first delivery of an event ID logs `OK`
-- repeated deliveries of the same ID within the TTL log `DROP duplicate`
-- messages are still ACKed
-- de-duplication is process-local and resets on restart
-
----
-
-**Environment variables**
-
-- `DEDUPE_TTL_MS` – how long an event ID is remembered, default `60000`
-- `DEDUPE_MAX_KEYS` – max IDs kept in memory, default `100000`
-- `PREFETCH` – consumer prefetch count
-- `CONCURRENCY` – parallel handler executions
+- the first delivery of an event ID is processed
+- repeated deliveries of the same ID within the TTL are acknowledged and skipped
+- duplicate messages do not reach the handler
 
 ---
 
-**Production notes**
+## Consumer option
+
+```ts
+await sub.consume({
+  prefetch: 10,
+  concurrency: 10,
+  dedupe: {
+    enabled: true,
+    ttlMs: 60_000,
+    maxKeys: 100_000,
+  },
+});
+```
+
+---
+
+## Production notes
 
 This pattern is useful, but it is not exactly-once delivery.
 
-For cross-instance, restart-safe, or exactly-once-like guarantees, use:
-
-- a database unique constraint
-- a Redis-backed de-duplication store
-- an outbox / transactional pattern
+For cross-instance, restart-safe, or exactly-once-like guarantees, use a database unique constraint, Redis-backed de-duplication, or an outbox pattern.

--- a/examples/01-confirms/dedupe/consumer.dedupe.ts
+++ b/examples/01-confirms/dedupe/consumer.dedupe.ts
@@ -1,6 +1,5 @@
 import { RabbitMQBroker } from "../../../lib";
 import type { EventEnvelope } from "../../../lib";
-import { makeMemoryDedupe } from "../../../lib/utils/dedupe";
 
 type Payload = { seq: number; label?: string };
 type DemoEvent = EventEnvelope<Payload>;
@@ -8,12 +7,6 @@ type DemoEvent = EventEnvelope<Payload>;
 (async () => {
   const EXCHANGE = "confirms.demo";
   const QUEUE = "confirms_demo_q";
-
-  // In-memory dedupe (TTL + max keys configurable via env)
-  const dedupe = makeMemoryDedupe({
-    ttlMs: Number(process.env.DEDUPE_TTL_MS ?? 60_000),
-    maxKeys: Number(process.env.DEDUPE_MAX_KEYS ?? 100_000),
-  });
 
   const broker = new RabbitMQBroker("dedupe.consumer");
 
@@ -25,26 +18,25 @@ type DemoEvent = EventEnvelope<Payload>;
     });
 
   sub.handle("*", async (_deliveryTag, ev) => {
-    // Idempotency check
-    if (!dedupe.checkAndRemember(ev)) {
-      console.log(
-        `[consumer] DROP duplicate id=${ev.id} name=${ev.name} seq=${ev.data?.seq ?? "?"}`
-      );
-      return;
-    }
-
     console.log(
       `[consumer] OK   id=${ev.id} name=${ev.name} seq=${ev.data?.seq ?? "?"}`
     );
 
-    // simulate work
     await new Promise((r) => setTimeout(r, 50));
   });
 
   const PREFETCH = Number(process.env.PREFETCH ?? 10);
   const CONCURRENCY = Number(process.env.CONCURRENCY ?? PREFETCH);
 
-  await sub.consume({ prefetch: PREFETCH, concurrency: CONCURRENCY });
+  await sub.consume({
+    prefetch: PREFETCH,
+    concurrency: CONCURRENCY,
+    dedupe: {
+      enabled: true,
+      ttlMs: Number(process.env.DEDUPE_TTL_MS ?? 60_000),
+      maxKeys: Number(process.env.DEDUPE_MAX_KEYS ?? 100_000),
+    },
+  });
 
   console.log(
     `[consumer] dedupe running (ttl=${process.env.DEDUPE_TTL_MS ?? "60s"}, maxKeys=${process.env.DEDUPE_MAX_KEYS ?? "100k"})`

--- a/examples/01-confirms/dedupe/publisher.dupes.ts
+++ b/examples/01-confirms/dedupe/publisher.dupes.ts
@@ -16,7 +16,7 @@ type DemoEvent = EventEnvelope<Payload>;
     .exchange<{ "demo.dupe": DemoEvent }>(EXCHANGE, {
       exchangeType: "topic",
       routingKey: "#",
-      publisherConfirms: true, // optional but realistic
+      publisherConfirms: true,
     });
 
   const makeDupe = event("demo.dupe", "v1").of<Payload>();
@@ -26,18 +26,17 @@ type DemoEvent = EventEnvelope<Payload>;
   const SECOND_SEND_DELAY_MS = Number(process.env.DUP_SECOND_DELAY_MS ?? 100);
 
   async function sendPair() {
-    // ONE envelope -> same id twice
-    const ev = makeDupe({ seq });
+    const currentSeq = seq++;
+    const ev = makeDupe({ seq: currentSeq });
 
     await pub.produce(ev);
-    console.log(`[publisher] sent seq=${seq} id=${ev.id}`);
+    console.log(`[publisher] sent seq=${currentSeq} id=${ev.id}`);
 
     setTimeout(async () => {
       await pub.produce(ev);
-      console.log(`[publisher] sent DUPLICATE seq=${seq} id=${ev.id}`);
+      console.log(`[publisher] sent DUPLICATE seq=${currentSeq} id=${ev.id}`);
     }, SECOND_SEND_DELAY_MS);
 
-    seq++;
     setTimeout(sendPair, PAIR_DELAY_MS);
   }
 

--- a/examples/02-rpc-advanced/requester.ts
+++ b/examples/02-rpc-advanced/requester.ts
@@ -2,7 +2,12 @@ import { RabbitMQBroker, event } from "../../lib";
 import type { EventEnvelope } from "../../lib";
 
 type AuthorizeReq = { orderId: string; amount: number; currency?: string };
-type AuthorizeRes = { orderId: string; approved: boolean; authId?: string; reason?: string };
+type AuthorizeRes = {
+  orderId: string;
+  approved: boolean;
+  authId?: string;
+  reason?: string;
+};
 
 (async () => {
   const EX = "rpc.demo";
@@ -40,29 +45,36 @@ type AuthorizeRes = { orderId: string; approved: boolean; authId?: string; reaso
         currency: "USD",
       });
 
-      req.meta = { expectsReply: true, timeoutMs: TIMEOUT };
-
       console.log(`[requester] → sending ${req.data.orderId} amount=${req.data.amount}`);
 
-      rpc.produce(req)
+      rpc
+        .request<AuthorizeRes>(req, {
+          timeoutMs: TIMEOUT,
+        })
         .then((reply) => {
-          console.log(`[requester] ← reply for ${req.data.orderId}:`, reply as AuthorizeRes);
+          console.log(`[requester] ← reply for ${req.data.orderId}:`, reply);
         })
         .catch((err) => {
           console.error(`[requester] ✖ error for ${req.data.orderId}:`, err.message);
         })
-        .finally(() => {
+        .finally(async () => {
           inFlight--;
           done++;
+
           if (done === TOTAL) {
             console.log("[requester] all requests completed");
+            await broker.close();
             process.exit(0);
           }
-          pump();
+
+          void pump();
         });
     }
   };
 
-  console.log(`[requester] sending ${TOTAL} RPCs (concurrency=${CONCURRENCY}, timeout=${TIMEOUT}ms)`);
-  pump();
+  console.log(
+    `[requester] sending ${TOTAL} RPCs (concurrency=${CONCURRENCY}, timeout=${TIMEOUT}ms)`
+  );
+
+  void pump();
 })();

--- a/examples/02-rpc/README.md
+++ b/examples/02-rpc/README.md
@@ -2,7 +2,7 @@
 
 This example shows **RPC-style request/response** using RabbitMQ.
 
-A requester sends a message and waits for a reply from a responder.
+A requester sends a message and waits for a typed reply from a responder.
 
 ---
 
@@ -12,7 +12,7 @@ A requester sends a message and waits for a reply from a responder.
   Handles `payments.charge` requests and returns a response.
 
 - `requester.ts`  
-  Sends one RPC request and waits for the reply.
+  Sends one RPC request using the Phase 2 `request<TReply>()` API.
 
 ---
 
@@ -28,45 +28,15 @@ npx ts-node-dev --transpile-only examples/02-rpc/requester.ts
 
 ---
 
-### Expected Output
-
-**Requester**
-```
-[Requester] sending charge request
-[Requester] reply: { ok: true, transactionId: "txn_ab12cd" }
-```
-
-**Responder**
-```
-[Responder] waiting for payments.charge
-[Responder] charging 42 USD for o-1001
-```
-
----
-
 ### How it works
 
-1. The requester publishes a message with:
-   - `expectsReply: true`
-   - a timeout
+```ts
+const reply = await cli.request<Res>(
+  charge(payload),
+  { timeoutMs: 5000 }
+);
+```
 
-2. The library:
-   - creates a temporary reply queue
-   - sets `replyTo` and `correlationId`
+Rabbit Relay creates a temporary reply queue, sets `replyTo` and `correlationId`, publishes the request, and resolves with the typed reply.
 
-3. The responder:
-   - processes the request
-   - returns a value
-
-4. The requester:
-   - receives the reply
-   - resolves the promise
-
----
-
-### Takeaway
-
-- This is **messaging-based RPC**, not HTTP
-- Replies are normal messages
-- Timeouts are expected
-- Use this pattern for internal service communication
+The old `meta.expectsReply` style still works for backward compatibility.

--- a/examples/02-rpc/requester.ts
+++ b/examples/02-rpc/requester.ts
@@ -1,13 +1,13 @@
-import { RabbitMQBroker } from "../../lib";
-import { event } from "../../lib/eventFactories";
+import { RabbitMQBroker, event } from "../../lib";
 import type { EventEnvelope } from "../../lib";
 
 type Req = { orderId: string; amount: number; currency: string };
+type Res = { ok: boolean; transactionId?: string; reason?: string };
 type ChargeEvent = EventEnvelope<Req>;
 
 (async () => {
   const EX = "rpc.payments";
-  const Q  = "orders_rpc_client_queue";
+  const Q = "orders_rpc_client_queue";
   const TIMEOUT_MS = 5000;
 
   const broker = new RabbitMQBroker("rpc.requester");
@@ -21,23 +21,24 @@ type ChargeEvent = EventEnvelope<Req>;
 
   const charge = event("payments.charge", "v1").of<Req>();
 
-  const ev = charge({
-    orderId: "o-1001",
-    amount: 42,
-    currency: "USD",
-  });
-
-  ev.meta = {
-    expectsReply: true,
-    timeoutMs: TIMEOUT_MS,
-  };
-
   console.log("[Requester] sending charge request");
 
   try {
-    const reply = await cli.produce(ev);
+    const reply = await cli.request<Res>(
+      charge({
+        orderId: "o-1001",
+        amount: 42,
+        currency: "USD",
+      }),
+      {
+        timeoutMs: TIMEOUT_MS,
+      }
+    );
+
     console.log("[Requester] reply:", reply);
   } catch (err) {
     console.error("[Requester] ERROR:", err);
+  } finally {
+    await broker.close();
   }
 })();

--- a/examples/09-developer-experience/README.md
+++ b/examples/09-developer-experience/README.md
@@ -1,0 +1,36 @@
+# Developer Experience
+
+**What it shows:** the Phase 2 developer experience APIs in one small flow.
+
+This example demonstrates:
+
+- `withHeaders()`
+- `traceFrom()`
+- local middleware with `use()`
+- consumer `dedupe`
+- message size guard with `maxMessageBytes`
+- typed RPC with `request<TReply>()`
+
+---
+
+## Run
+
+```bash
+# terminal 1
+npx ts-node-dev --transpile-only examples/09-developer-experience/consumer.ts
+
+# terminal 2
+npx ts-node-dev --transpile-only examples/09-developer-experience/publisher.ts
+```
+
+---
+
+## Expected behavior
+
+The consumer shows middleware logs.
+
+The duplicate event is skipped by `consume({ dedupe })`.
+
+The publisher catches a typed `MessageTooLargeError`.
+
+The RPC request receives a typed reply.

--- a/examples/09-developer-experience/consumer.ts
+++ b/examples/09-developer-experience/consumer.ts
@@ -36,7 +36,7 @@ type Pong = {
       "dx.ping": EventEnvelope<Ping>;
     }>("dx.orders.ex", {
       exchangeType: "topic",
-      routingKey: "dx.*",
+      routingKey: "dx.#",
       publisherConfirms: true,
       maxMessageBytes: 256 * 1024,
     });

--- a/examples/09-developer-experience/consumer.ts
+++ b/examples/09-developer-experience/consumer.ts
@@ -1,0 +1,113 @@
+import {
+  RabbitMQBroker,
+  event,
+  traceFrom,
+} from "../../lib";
+import type { EventEnvelope } from "../../lib";
+
+type OrderCreated = {
+  orderId: string;
+  amount: number;
+};
+
+type PaymentRequested = {
+  orderId: string;
+  amount: number;
+};
+
+type Ping = {
+  id: string;
+};
+
+type Pong = {
+  ok: boolean;
+  message: string;
+};
+
+(async () => {
+  const broker = new RabbitMQBroker("dx.consumer", {
+    maxMessageBytes: 256 * 1024,
+  });
+
+  const orders = await broker
+    .queue("dx.orders.q")
+    .exchange<{
+      "dx.order.created": EventEnvelope<OrderCreated>;
+      "dx.ping": EventEnvelope<Ping>;
+    }>("dx.orders.ex", {
+      exchangeType: "topic",
+      routingKey: "dx.*",
+      publisherConfirms: true,
+      maxMessageBytes: 256 * 1024,
+    });
+
+  const payments = await broker
+    .queue("dx.payments.publisher.q")
+    .exchange<{
+      "dx.payment.requested": EventEnvelope<PaymentRequested>;
+    }>("dx.payments.ex", {
+      exchangeType: "topic",
+      routingKey: "dx.payment.requested",
+      publisherConfirms: true,
+    });
+
+  const paymentRequested = event("dx.payment.requested", "v1").of<PaymentRequested>();
+
+  orders.use(async (ctx, next) => {
+    console.log("[middleware] before", {
+      queue: ctx.queue,
+      event: ctx.event.name,
+      corrId: ctx.event.meta?.corrId,
+      causationId: ctx.event.meta?.causationId,
+    });
+
+    await next();
+
+    console.log("[middleware] after", ctx.event.name);
+  });
+
+  orders.handle("dx.order.created", async (_id, ev) => {
+    console.log("[consumer] order received:", ev.data);
+
+    await payments.produce(
+      paymentRequested(
+        {
+          orderId: ev.data.orderId,
+          amount: ev.data.amount,
+        },
+        traceFrom(ev, {
+          headers: {
+            source: "dx.consumer",
+          },
+        })
+      )
+    );
+
+    console.log("[consumer] emitted dx.payment.requested");
+  });
+
+  orders.handle("dx.ping", async (_id, ev): Promise<Pong> => {
+    console.log("[consumer] ping received:", ev.data);
+
+    return {
+      ok: true,
+      message: `pong for ${ev.data.id}`,
+    };
+  });
+
+  await orders.consume({
+    prefetch: 10,
+    concurrency: 2,
+    dedupe: {
+      enabled: true,
+      ttlMs: 60_000,
+    },
+  });
+
+  console.log("[consumer] developer experience consumer listening");
+
+  process.on("SIGTERM", async () => {
+    await broker.close();
+    process.exit(0);
+  });
+})();

--- a/examples/09-developer-experience/publisher.ts
+++ b/examples/09-developer-experience/publisher.ts
@@ -1,0 +1,109 @@
+import {
+  RabbitMQBroker,
+  MessageTooLargeError,
+  event,
+  withHeaders,
+  withCorrelation,
+} from "../../lib";
+import type { EventEnvelope } from "../../lib";
+
+type OrderCreated = {
+  orderId: string;
+  amount: number;
+  note?: string;
+};
+
+type Ping = {
+  id: string;
+};
+
+type Pong = {
+  ok: boolean;
+  message: string;
+};
+
+(async () => {
+  const broker = new RabbitMQBroker("dx.publisher", {
+    maxMessageBytes: 256 * 1024,
+  });
+
+  const pub = await broker
+    .queue("dx.publisher.q")
+    .exchange<{
+      "dx.order.created": EventEnvelope<OrderCreated>;
+      "dx.ping": EventEnvelope<Ping>;
+    }>("dx.orders.ex", {
+      exchangeType: "topic",
+      routingKey: "dx.order.created",
+      publisherConfirms: true,
+      maxMessageBytes: 256 * 1024,
+    });
+
+  const orderCreated = event("dx.order.created", "v1").of<OrderCreated>();
+  const ping = event("dx.ping", "v1").of<Ping>();
+
+  const order = withCorrelation(
+    withHeaders(
+      orderCreated({
+        orderId: "o-1001",
+        amount: 42,
+      }),
+      {
+        tenantId: "tenant-1",
+        source: "dx.publisher",
+      }
+    ),
+    "corr-demo-1"
+  );
+
+  console.log("[publisher] sending order");
+  await pub.produce(order);
+
+  console.log("[publisher] sending duplicate order with same event id");
+  await pub.produce(order);
+
+  console.log("[publisher] sending RPC ping");
+  const reply = await pub.request<Pong>(
+    withHeaders(
+      ping({
+        id: "ping-1",
+      }),
+      {
+        source: "dx.publisher",
+      }
+    ),
+    {
+      timeoutMs: 5000,
+      routingKey: "dx.ping",
+    }
+  );
+
+  console.log("[publisher] RPC reply:", reply);
+
+  console.log("[publisher] testing message size guard");
+
+  try {
+    await pub.publish(
+      orderCreated({
+        orderId: "too-large",
+        amount: 1,
+        note: "x".repeat(300 * 1024),
+      }),
+      {
+        maxMessageBytes: 8 * 1024,
+      }
+    );
+  } catch (err) {
+    if (err instanceof MessageTooLargeError) {
+      console.log("[publisher] caught MessageTooLargeError:", {
+        eventName: err.eventName,
+        sizeBytes: err.sizeBytes,
+        maxBytes: err.maxBytes,
+      });
+    } else {
+      throw err;
+    }
+  }
+
+  await broker.close();
+})();

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,7 +27,7 @@ user / password
 npx ts-node-dev --transpile-only <path-to-example>
 ```
 
-Most examples require **multiple terminals** (publisher + consumer).
+Most examples require **multiple terminals**.
 
 ---
 
@@ -35,122 +35,79 @@ Most examples require **multiple terminals** (publisher + consumer).
 
 ### 00 — Basics
 
-Foundational routing patterns.
-
 - `direct/` — routing by key
 - `fanout/` — broadcast to all
 - `topic-microservices/` — simple multi-service flow
 
----
-
 ### 01 — Publisher Confirms + Dedupe
 
-Reliable publishing with broker acknowledgements.
-
 - confirm publishing
-- consumer-side de-duplication
-
----
+- consumer-side de-duplication with `consume({ dedupe })`
 
 ### 02 — RPC
 
-Request / reply over RabbitMQ.
-
-- request/reply pattern
+- typed `request<TReply>()`
 - timeouts
 - prefetch and concurrency
 
----
-
-### 03 — Dead Letter Queues (DLQ)
-
-Immediate failure routing using the built-in `deadLetter` helper.
+### 03 — Dead Letter Queues
 
 - failed messages
 - DLX/DLQ topology
 - `onError: "dead-letter"`
 
----
-
 ### 04 — Plugins
 
-Extending behavior without touching business logic.
-
-- plugin definition
-- lifecycle hooks
+- global lifecycle hooks
 - logging, metrics, headers, tracing
-
----
 
 ### 05 — Backpressure
 
-What happens when publishers are faster than consumers.
-
 - fast publisher
 - slow consumer
-- observable queue growth
-- natural RabbitMQ flow control
-
-This example demonstrates **healthy overload behavior**, not failure.
-
----
+- RabbitMQ flow control
 
 ### 06 — Retry + DLQ
-
-Bounded retries before dead-lettering.
 
 - `onError: "retry"`
 - retry metadata headers
 - final `then: "dead-letter"`
 
----
-
 ### 07 — amqplib Escape Hatch
 
-Native RabbitMQ / `amqplib` access when needed.
-
-- queue passthrough options
-- exchange passthrough options
+- queue/exchange passthrough options
 - publish options
 - raw channel access
 
----
-
 ### 08 — Health + Shutdown
-
-Production lifecycle APIs.
 
 - `broker.health()`
 - `broker.close()`
 - shutdown signal handling
 
+### 09 — Developer Experience
+
+- `request<TReply>()`
+- `withHeaders()`
+- `traceFrom()`
+- local middleware with `use()`
+- `consume({ dedupe })`
+- `maxMessageBytes`
+- `MessageTooLargeError`
+
 ---
 
 ## Housekeeping
-
-Useful commands while experimenting.
-
-### List queues
-
-```bash
-docker exec -it rabbitmq rabbitmqctl list_queues name messages_ready messages_unacknowledged arguments
-```
-
-### List exchanges
-
-```bash
-docker exec -it rabbitmq rabbitmqctl list_exchanges name type durable
-```
-
-### Delete a specific queue
-
-```bash
-docker exec -it rabbitmq rabbitmqctl delete_queue orders.queue
-```
 
 ### Reset local RabbitMQ data
 
 ```bash
 docker compose -f examples/docker-compose.yml down -v
 docker compose -f examples/docker-compose.yml up -d
+```
+
+### List queues
+
+```bash
+docker exec -it rabbitmq rabbitmqctl list_queues name messages_ready messages_unacknowledged arguments
 ```

--- a/lib/consumer.ts
+++ b/lib/consumer.ts
@@ -3,6 +3,7 @@ import { pluginManager } from "./pluginManager";
 import { EventEnvelope } from "./eventFactories";
 import { ConsumeOptions } from "./types";
 import { publishWithBackpressure } from "./backpressure";
+import { Dedupe, makeMemoryDedupe } from "./utils/dedupe";
 
 export type HandlerMap = Map<
   string,
@@ -35,9 +36,28 @@ export function createConsumer(params: {
   let retryAttempts = 0;
   let retryThen: FinalRetryAction = "dead-letter";
 
+  let dedupe: Dedupe | undefined;
+
   const pendingMessages: ConsumeMessage[] = [];
   let activeHandlers = 0;
   let stopping = false;
+
+  function resolveDedupe(opts?: ConsumeOptions): Dedupe | undefined {
+    const configured = opts?.dedupe;
+
+    if (!configured) return undefined;
+
+    if (
+      "checkAndRemember" in configured &&
+      typeof configured.checkAndRemember === "function"
+    ) {
+      return configured;
+    }
+
+    if (configured.enabled === false) return undefined;
+
+    return makeMemoryDedupe(configured);
+  }
 
   function getRetryCount(msg: ConsumeMessage): number {
     const raw = msg.properties.headers?.[RETRY_COUNT_HEADER];
@@ -245,6 +265,16 @@ export function createConsumer(params: {
       return;
     }
 
+    if (dedupe && !dedupe.checkAndRemember(payload)) {
+      try {
+        ch.ack(msg);
+      } catch (e) {
+        console.error("Ack duplicate failed:", e);
+      }
+
+      return;
+    }
+
     const handler =
       (handlers.get(payload.name) as any) || (handlers.get("*") as any);
 
@@ -356,6 +386,8 @@ export function createConsumer(params: {
         "[broker] consume retry.attempts must be greater than 0 when onError='retry'"
       );
     }
+
+    dedupe = resolveDedupe(opts);
 
     stopping = false;
 

--- a/lib/consumer.ts
+++ b/lib/consumer.ts
@@ -3,7 +3,7 @@ import { pluginManager } from "./pluginManager";
 import { EventEnvelope } from "./eventFactories";
 import { ConsumeOptions } from "./types";
 import { publishWithBackpressure } from "./backpressure";
-import { Dedupe, makeMemoryDedupe } from "./utils/dedupe";
+import { Dedupe, DedupeOpts, makeMemoryDedupe } from "./utils/dedupe";
 
 export type HandlerMap = Map<
   string,
@@ -17,6 +17,10 @@ const LAST_ERROR_HEADER = "x-rabbit-relay-last-error";
 
 type ErrorAction = "ack" | "requeue" | "dead-letter" | "retry";
 type FinalRetryAction = "ack" | "requeue" | "dead-letter";
+
+type BuiltInDedupeConfig = DedupeOpts & {
+  enabled?: boolean;
+};
 
 export function createConsumer(params: {
   queueName: string;
@@ -42,21 +46,29 @@ export function createConsumer(params: {
   let activeHandlers = 0;
   let stopping = false;
 
+  function isDedupeInstance(value: unknown): value is Dedupe {
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      "checkAndRemember" in value &&
+      typeof (value as Dedupe).checkAndRemember === "function"
+    );
+  }
+
   function resolveDedupe(opts?: ConsumeOptions): Dedupe | undefined {
     const configured = opts?.dedupe;
 
     if (!configured) return undefined;
 
-    if (
-      "checkAndRemember" in configured &&
-      typeof configured.checkAndRemember === "function"
-    ) {
+    if (isDedupeInstance(configured)) {
       return configured;
     }
 
-    if (configured.enabled === false) return undefined;
+    const config = configured as BuiltInDedupeConfig;
 
-    return makeMemoryDedupe(configured);
+    if (config.enabled === false) return undefined;
+
+    return makeMemoryDedupe(config);
   }
 
   function getRetryCount(msg: ConsumeMessage): number {
@@ -372,7 +384,7 @@ export function createConsumer(params: {
     if (concurrency > prefetchCount) {
       console.warn(
         `[broker] consume concurrency (${concurrency}) is greater than prefetch (${prefetchCount}). ` +
-          `Concurrency will be limited by RabbitMQ prefetch.`
+        `Concurrency will be limited by RabbitMQ prefetch.`
       );
     }
 
@@ -451,9 +463,9 @@ export function createConsumer(params: {
       retry:
         onError === "retry"
           ? {
-              attempts: retryAttempts,
-              then: retryThen,
-            }
+            attempts: retryAttempts,
+            then: retryThen,
+          }
           : undefined,
     };
   }

--- a/lib/consumer.ts
+++ b/lib/consumer.ts
@@ -1,7 +1,7 @@
 import { Channel, ConsumeMessage, Options } from "amqplib";
 import { pluginManager } from "./pluginManager";
 import { EventEnvelope } from "./eventFactories";
-import { ConsumeOptions } from "./types";
+import { ConsumeMiddleware, ConsumeMiddlewareContext, ConsumeOptions } from "./types";
 import { publishWithBackpressure } from "./backpressure";
 import { Dedupe, DedupeOpts, makeMemoryDedupe } from "./utils/dedupe";
 
@@ -25,8 +25,9 @@ type BuiltInDedupeConfig = DedupeOpts & {
 export function createConsumer(params: {
   queueName: string;
   handlers: HandlerMap;
+  middlewares: ConsumeMiddleware[];
 }) {
-  const { queueName, handlers } = params;
+  const { queueName, handlers, middlewares } = params;
 
   let consumerTag: string | undefined;
   let isConsuming = false;
@@ -69,6 +70,32 @@ export function createConsumer(params: {
     if (config.enabled === false) return undefined;
 
     return makeMemoryDedupe(config);
+  }
+
+  async function runMiddlewareChain(
+    ctx: ConsumeMiddlewareContext,
+    handler: () => Promise<void>
+  ): Promise<void> {
+    let index = -1;
+
+    async function dispatch(i: number): Promise<void> {
+      if (i <= index) {
+        throw new Error("[broker] next() called multiple times in middleware");
+      }
+
+      index = i;
+
+      const middleware = middlewares[i];
+
+      if (!middleware) {
+        await handler();
+        return;
+      }
+
+      await middleware(ctx, () => dispatch(i + 1));
+    }
+
+    await dispatch(0);
   }
 
   function getRetryCount(msg: ConsumeMessage): number {
@@ -293,9 +320,18 @@ export function createConsumer(params: {
     try {
       await pluginManager.executeHook("beforeProcess", id, payload);
 
-      if (handler) {
-        result = await handler(id, payload as any);
-      }
+      await runMiddlewareChain(
+        {
+          id,
+          event: payload,
+          queue: queueName,
+        },
+        async () => {
+          if (handler) {
+            result = await handler(id, payload as any);
+          }
+        }
+      );
 
       await pluginManager.executeHook("afterProcess", id, payload, result);
     } catch (err) {
@@ -463,9 +499,9 @@ export function createConsumer(params: {
       retry:
         onError === "retry"
           ? {
-            attempts: retryAttempts,
-            then: retryThen,
-          }
+              attempts: retryAttempts,
+              then: retryThen,
+            }
           : undefined,
     };
   }

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,0 +1,22 @@
+export class MessageTooLargeError extends Error {
+  public readonly eventName: string;
+  public readonly sizeBytes: number;
+  public readonly maxBytes: number;
+
+  constructor(params: {
+    eventName: string;
+    sizeBytes: number;
+    maxBytes: number;
+  }) {
+    super(
+      `MessageTooLargeError: event '${params.eventName}' is ${params.sizeBytes} bytes, ` +
+        `max allowed is ${params.maxBytes} bytes. ` +
+        `Store large payloads externally and publish a reference instead.`
+    );
+
+    this.name = "MessageTooLargeError";
+    this.eventName = params.eventName;
+    this.sizeBytes = params.sizeBytes;
+    this.maxBytes = params.maxBytes;
+  }
+}

--- a/lib/eventFactories.ts
+++ b/lib/eventFactories.ts
@@ -92,6 +92,33 @@ export function withCausation<T extends EventEnvelope>(
   });
 }
 
+/**
+ * Create metadata for a child event caused by a parent event.
+ *
+ * Behavior:
+ * - preserves parent corrId if present
+ * - otherwise uses parent.id as the new corrId
+ * - sets causationId to parent.id
+ * - copies parent headers by default
+ * - allows overriding/adding metadata
+ */
+export function traceFrom(
+  parent: EventEnvelope,
+  meta?: EventMeta
+): EventMeta {
+  const { headers: extraHeaders, ...restMeta } = meta ?? {};
+
+  return {
+    corrId: parent.meta?.corrId ?? parent.id,
+    causationId: parent.id,
+    ...restMeta,
+    headers: {
+      ...(parent.meta?.headers ?? {}),
+      ...(extraHeaders ?? {}),
+    },
+  };
+}
+
 function randomId(): string {
   try {
     return (

--- a/lib/eventFactories.ts
+++ b/lib/eventFactories.ts
@@ -34,6 +34,64 @@ export function expectReply(meta?: EventMeta, timeoutMs?: number): EventMeta {
   };
 }
 
+/**
+ * Merge metadata into an event envelope.
+ *
+ * Existing event metadata is preserved unless explicitly overridden.
+ * Headers are merged separately so existing headers are not lost.
+ */
+export function withMeta<T extends EventEnvelope>(
+  event: T,
+  meta: EventMeta
+): T {
+  event.meta = {
+    ...(event.meta ?? {}),
+    ...(meta ?? {}),
+    headers: {
+      ...(event.meta?.headers ?? {}),
+      ...(meta.headers ?? {}),
+    },
+  };
+
+  return event;
+}
+
+/**
+ * Merge application headers into an event envelope.
+ */
+export function withHeaders<T extends EventEnvelope>(
+  event: T,
+  headers: Record<string, string>
+): T {
+  return withMeta(event, {
+    headers,
+  });
+}
+
+/**
+ * Set or override the correlation ID for an event.
+ */
+export function withCorrelation<T extends EventEnvelope>(
+  event: T,
+  corrId: string
+): T {
+  return withMeta(event, {
+    corrId,
+  });
+}
+
+/**
+ * Set or override the causation ID for an event.
+ */
+export function withCausation<T extends EventEnvelope>(
+  event: T,
+  causationId: string
+): T {
+  return withMeta(event, {
+    causationId,
+  });
+}
+
 function randomId(): string {
   try {
     return (

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,3 +3,4 @@ export * from "./eventFactories";
 export * from "./pluginManager";
 export * from "./utils/dedupe";
 export * from "./types";
+export * from "./errors";

--- a/lib/publisher.ts
+++ b/lib/publisher.ts
@@ -2,9 +2,15 @@ import { Channel, ConfirmChannel, Options } from "amqplib";
 import { getRabbitMQConfirmChannel } from "./config";
 import { pluginManager } from "./pluginManager";
 import { EventEnvelope, EventMeta } from "./eventFactories";
-import { ExchangeConfig, InternalCfg, PublishOptions, RequestOptions } from "./types";
+import {
+  ExchangeConfig,
+  InternalCfg,
+  PublishOptions,
+  RequestOptions,
+} from "./types";
 import { publishWithBackpressure, PublishChannel } from "./backpressure";
 import { generateUuid } from "./uuid";
+import { MessageTooLargeError } from "./errors";
 
 function buildPublishProps(
   event: EventEnvelope,
@@ -45,6 +51,26 @@ function buildRpcPublishProps(
   };
 }
 
+function assertMessageSize(
+  event: EventEnvelope,
+  content: Buffer,
+  maxMessageBytes?: number
+) {
+  if (maxMessageBytes == null) return;
+
+  if (!Number.isFinite(maxMessageBytes) || maxMessageBytes <= 0) {
+    throw new Error("[broker] maxMessageBytes must be a positive number");
+  }
+
+  if (content.length > maxMessageBytes) {
+    throw new MessageTooLargeError({
+      eventName: event.name,
+      sizeBytes: content.length,
+      maxBytes: maxMessageBytes,
+    });
+  }
+}
+
 export function createPublisher(params: {
   exchangeName: string;
   exchangeConfig: ExchangeConfig;
@@ -54,6 +80,23 @@ export function createPublisher(params: {
 }) {
   const { exchangeName, exchangeConfig, defaultCfg, getChannel, getBackoffMs } =
     params;
+
+  const resolveMaxMessageBytes = (opts?: PublishOptions): number | undefined => {
+    return (
+      opts?.maxMessageBytes ??
+      exchangeConfig.maxMessageBytes ??
+      defaultCfg.maxMessageBytes
+    );
+  };
+
+  const serializeEvent = (
+    event: EventEnvelope,
+    opts?: PublishOptions
+  ): Buffer => {
+    const content = Buffer.from(JSON.stringify(event));
+    assertMessageSize(event, content, resolveMaxMessageBytes(opts));
+    return content;
+  };
 
   const getPubChannel = async (): Promise<PublishChannel> => {
     if (exchangeConfig.publisherConfirms ?? defaultCfg.publisherConfirms) {
@@ -85,6 +128,8 @@ export function createPublisher(params: {
   ): Promise<void> => {
     await pluginManager.executeHook("beforeProduce", evt);
 
+    const content = serializeEvent(evt, opts);
+
     await safePublish((ch) => {
       const props = buildPublishProps(evt, opts);
 
@@ -92,7 +137,7 @@ export function createPublisher(params: {
         ch,
         exchangeName,
         opts?.routingKey ?? evt.name,
-        Buffer.from(JSON.stringify(evt)),
+        content,
         props
       );
     });
@@ -114,6 +159,8 @@ export function createPublisher(params: {
 
     await pluginManager.executeHook("beforeProduce", evt);
 
+    const content = serializeEvent(evt, opts);
+
     await safePublish(async (pubCh) => {
       const props = buildRpcPublishProps(evt, correlationId, temp.queue, opts);
 
@@ -121,7 +168,7 @@ export function createPublisher(params: {
         pubCh,
         exchangeName,
         opts?.routingKey ?? evt.name,
-        Buffer.from(JSON.stringify(evt)),
+        content,
         props
       );
     });

--- a/lib/publisher.ts
+++ b/lib/publisher.ts
@@ -2,7 +2,7 @@ import { Channel, ConfirmChannel, Options } from "amqplib";
 import { getRabbitMQConfirmChannel } from "./config";
 import { pluginManager } from "./pluginManager";
 import { EventEnvelope, EventMeta } from "./eventFactories";
-import { ExchangeConfig, InternalCfg, PublishOptions } from "./types";
+import { ExchangeConfig, InternalCfg, PublishOptions, RequestOptions } from "./types";
 import { publishWithBackpressure, PublishChannel } from "./backpressure";
 import { generateUuid } from "./uuid";
 
@@ -245,5 +245,20 @@ export function createPublisher(params: {
     return publishOne(event as EventEnvelope, opts);
   };
 
-  return { produce, produceMany, publish };
+  const request = async <TReply = unknown>(
+    event: EventEnvelope,
+    opts?: RequestOptions
+  ): Promise<TReply> => {
+    const evt = event as EventEnvelope & { meta?: EventMeta };
+
+    evt.meta = {
+      ...(evt.meta ?? {}),
+      expectsReply: true,
+      ...(opts?.timeoutMs != null ? { timeoutMs: opts.timeoutMs } : {}),
+    };
+
+    return requestOne(evt, opts) as Promise<TReply>;
+  };
+
+  return { produce, produceMany, publish, request };
 }

--- a/lib/rabbitmqBroker.ts
+++ b/lib/rabbitmqBroker.ts
@@ -9,6 +9,7 @@ import {
   PublishOptions,
   RequestOptions,
   BrokerHealth,
+  ConsumeMiddleware,
 } from "./types";
 import { ReconnectController } from "./reconnect";
 import { createAssertTopology } from "./topology";
@@ -142,9 +143,12 @@ export class RabbitMQBroker {
       (id: string | number, event: EventEnvelope) => Promise<unknown>
     >();
 
+    const middlewares: ConsumeMiddleware[] = [];
+
     const consumer = createConsumer({
       queueName,
       handlers,
+      middlewares,
     });
 
     this.registeredConsumers.push({
@@ -164,6 +168,11 @@ export class RabbitMQBroker {
       await assertTopology(ch);
       await consumer.resumeOnReconnect(ch);
     });
+
+    const use = (middleware: ConsumeMiddleware): BrokerInterface<TEvents> => {
+      middlewares.push(middleware);
+      return brokerInterface;
+    };
 
     const handle = <K extends keyof TEvents>(
       eventName: K | "*",
@@ -216,6 +225,7 @@ export class RabbitMQBroker {
     };
 
     const brokerInterface: BrokerInterface<TEvents> = {
+      use,
       handle,
       consume,
       produce,

--- a/lib/rabbitmqBroker.ts
+++ b/lib/rabbitmqBroker.ts
@@ -48,6 +48,7 @@ export class RabbitMQBroker {
       durable: config.durable ?? true,
       publisherConfirms: config.publisherConfirms ?? false,
       queueArgs: config.queueArgs,
+      maxMessageBytes: config.maxMessageBytes,
       passiveQueue: config.passiveQueue ?? false,
       deadLetter: config.deadLetter,
       amqp: config.amqp,

--- a/lib/rabbitmqBroker.ts
+++ b/lib/rabbitmqBroker.ts
@@ -7,6 +7,7 @@ import {
   ConsumeOptions,
   QueueConfig,
   PublishOptions,
+  RequestOptions,
   BrokerHealth,
 } from "./types";
 import { ReconnectController } from "./reconnect";
@@ -198,6 +199,16 @@ export class RabbitMQBroker {
       return publisher.publish<TEvents, K>(event, opts);
     };
 
+    const request = async <
+      TReply = unknown,
+      K extends keyof TEvents = keyof TEvents
+    >(
+      event: TEvents[K],
+      opts?: RequestOptions
+    ): Promise<TReply> => {
+      return publisher.request<TReply>(event as EventEnvelope, opts);
+    };
+
     const withChannel = async <T>(fn: (channel: Channel) => Promise<T> | T): Promise<T> => {
       const channel = await this.getChannel();
       return fn(channel);
@@ -209,6 +220,7 @@ export class RabbitMQBroker {
       produce,
       produceMany,
       publish,
+      request,
       withChannel,
       health: () => this.health(),
       with: <U extends Record<string, (...args: any[]) => EventEnvelope>>(events: U) => {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -95,6 +95,11 @@ export interface PublishOptions {
   amqp?: Pick<AmqpPassthroughOptions, "publish">;
 }
 
+export interface RequestOptions extends PublishOptions {
+  /** Timeout while waiting for RPC reply. Default: 5000. */
+  timeoutMs?: number;
+}
+
 export interface RetryOptions {
   /** Number of retry attempts before final failure behavior. */
   attempts: number;
@@ -150,6 +155,17 @@ export interface BrokerInterface<TEvents extends Record<string, EventEnvelope>> 
     event: TEvents[K],
     opts?: PublishOptions
   ): Promise<void | unknown>;
+
+  /**
+   * Send one event as an RPC-style request and wait for a typed reply.
+   *
+   * This is a cleaner alternative to manually setting:
+   * event.meta = { expectsReply: true, timeoutMs: ... }
+   */
+  request<TReply = unknown, K extends keyof TEvents = keyof TEvents>(
+    event: TEvents[K],
+    opts?: RequestOptions
+  ): Promise<TReply>;
 
   /** Escape hatch for advanced amqplib usage. */
   withChannel<T>(fn: (channel: Channel) => Promise<T> | T): Promise<T>;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -166,11 +166,34 @@ export interface ConsumeOptions {
   amqp?: Pick<AmqpPassthroughOptions, "consume">;
 }
 
+export interface ConsumeMiddlewareContext {
+  /** RabbitMQ delivery tag. */
+  id: string | number;
+
+  /** Parsed Rabbit Relay event envelope. */
+  event: EventEnvelope;
+
+  /** Queue currently consuming this message. */
+  queue: string;
+}
+
+export type ConsumeMiddleware = (
+  ctx: ConsumeMiddlewareContext,
+  next: () => Promise<void>
+) => Promise<void>;
+
 /**
  * Generic Broker Interface:
  * TEvents maps event name keys -> EventEnvelope types.
  */
 export interface BrokerInterface<TEvents extends Record<string, EventEnvelope>> {
+  /**
+   * Register local middleware for this broker interface.
+   *
+   * Middleware wraps handler execution for this queue/exchange binding only.
+   */
+  use(middleware: ConsumeMiddleware): BrokerInterface<TEvents>;
+
   handle<K extends keyof TEvents>(
     eventName: K | "*",
     handler: (id: string | number, event: TEvents[K]) => Promise<unknown>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,6 @@
 import { Channel, Options } from "amqplib";
 import { EventEnvelope } from "./eventFactories";
+import { Dedupe, DedupeOpts } from "./utils/dedupe";
 
 export interface AmqpPassthroughOptions {
   queue?: Options.AssertQueue;
@@ -111,6 +112,16 @@ export interface RetryOptions {
   then?: "ack" | "requeue" | "dead-letter";
 }
 
+export type ConsumeDedupeOptions =
+  | Dedupe
+  | (DedupeOpts & {
+      /**
+       * Enable/disable built-in memory dedupe.
+       * Default: true when dedupe config is provided.
+       */
+      enabled?: boolean;
+    });
+
 export interface ConsumeOptions {
   /** Max unacked messages this consumer can hold. Also default concurrency. */
   prefetch?: number;
@@ -126,6 +137,17 @@ export interface ConsumeOptions {
 
   /** Retry policy when onError is "retry". */
   retry?: RetryOptions;
+
+  /**
+   * Optional consumer-side de-duplication.
+   *
+   * Pass either:
+   * - a Dedupe instance, for example makeMemoryDedupe(...)
+   * - a config object, for example { enabled: true, ttlMs: 60000 }
+   *
+   * Duplicate messages are acknowledged and skipped.
+   */
+  dedupe?: ConsumeDedupeOptions;
 
   /** Native amqplib consume options. */
   amqp?: Pick<AmqpPassthroughOptions, "consume">;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -71,6 +71,13 @@ export interface ExchangeConfig {
   queueArgs?: Options.AssertQueue["arguments"];
 
   /**
+   * Maximum serialized event size in bytes.
+   *
+   * Can be configured at broker/exchange level and overridden per publish/request.
+   */
+  maxMessageBytes?: number;
+
+  /**
    * If true, do NOT declare the queue; only check it exists.
    * Use this when a separate setup step has already created the queue with specific args.
    */
@@ -91,6 +98,12 @@ export interface ExchangeConfig {
 export interface PublishOptions {
   /** Override the routing key for this publish. Defaults to event.name. */
   routingKey?: string;
+
+  /**
+   * Maximum serialized event size in bytes for this publish/request.
+   * Overrides broker/exchange-level maxMessageBytes.
+   */
+  maxMessageBytes?: number;
 
   /** Native amqplib publish options. */
   amqp?: Pick<AmqpPassthroughOptions, "publish">;
@@ -208,6 +221,7 @@ export type InternalCfg = {
   durable: boolean;
   publisherConfirms: boolean;
   queueArgs?: Options.AssertQueue["arguments"];
+  maxMessageBytes?: number;
   passiveQueue: boolean;
   deadLetter?: DeadLetterConfig;
   amqp?: Pick<AmqpPassthroughOptions, "exchange" | "queue" | "bind">;


### PR DESCRIPTION
## Summary

This PR adds the Phase 2 Developer Experience feature set for Rabbit Relay.

It keeps the existing API backward compatible while making common messaging patterns cleaner, safer, and easier for developers to use.

## Added

- Added typed RPC API with `request<TReply>()`.
- Added metadata and header helpers:
  - `withMeta()`
  - `withHeaders()`
  - `withCorrelation()`
  - `withCausation()`
- Added trace propagation helper with `traceFrom(parentEvent)`.
- Added consumer-side dedupe option through `consume({ dedupe })`.
- Added message size guard with `maxMessageBytes`.
- Added typed `MessageTooLargeError`.
- Added local consumer middleware with `sub.use(...)`.

## Updated

- Updated RPC examples to use the new `request<TReply>()` API.
- Updated dedupe example to use `consume({ dedupe })`.
- Added new developer experience example:
  - `examples/09-developer-experience`
- Updated package usage test to cover Phase 2 public APIs.
- Updated docs for:
  - RPC
  - headers/tracing
  - middleware
  - TTL dedupe
  - message size guard
  - quickstart
  - configuration
  - API reference
  - developer experience example

## Backward Compatibility

This PR is additive and is intended to remain backward compatible with existing public usage patterns.

Existing usage should continue to work:

- `produce(event)`
- `produceMany(...events)`
- `publish(event, options)`
- RPC via `meta.expectsReply`
- `consume()`
- `handle()`
- `.with(...)`
- plugin hooks
- manual `makeMemoryDedupe()` usage
- existing RabbitMQ topology options

Manually validated:

- `examples/09-developer-experience`
  - middleware
  - headers/correlation
  - `traceFrom`
  - `consume({ dedupe })`
  - `request<TReply>()`
  - `MessageTooLargeError`

- `examples/02-rpc`
  - basic typed request/reply

- `examples/02-rpc-advanced`
  - normal concurrent replies
  - slow responder timeout behavior

- `examples/01-confirms/dedupe`
  - `consume({ dedupe })`
  - duplicate event IDs skipped before handler

## Notes

- Middleware is local to a broker interface.
- Plugins remain process-global and are still supported.
- Message size guard checks the serialized event envelope before publishing.
- Built-in dedupe is in-memory and process-local.