### PR TITLE
fix: polish public API behavior before 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ const pub = await broker
 // Define typed events (name + version)
 const send = event("send", "v1").of<{ message: string }>();
 
-// Build a typed API and publish
+// Build a typed publish API.
+// Calling api.send(...) creates the event and publishes it.
 const api = pub.with({ send });
 await api.send({ message: "hello world" });
 ```
@@ -100,6 +101,55 @@ const pub = await broker
 const hello = event("hello", "v1").of<{ msg: string }>();
 
 await pub.produce(hello({ msg: "world" }));
+```
+
+### Routing keys
+
+By default, Rabbit Relay publishes using the event name as the routing key.
+
+```ts
+const hello = event("hello", "v1").of<{ msg: string }>();
+
+await pub.produce(
+  hello({ msg: "world" })
+); // routing key: "hello"
+```
+
+If you configure a concrete `routingKey` on the exchange, Rabbit Relay uses it when publishing:
+
+```ts
+const pub = await broker
+  .queue("orders.q")
+  .exchange("orders.exchange", {
+    exchangeType: "topic",
+    routingKey: "orders.created",
+  });
+```
+
+For topic wildcard bindings such as `#` or `demo.*`, Rabbit Relay treats the value as a binding pattern and continues publishing by event name.
+
+```ts
+const pub = await broker
+  .queue("plugins.q")
+  .exchange("plugins.exchange", {
+    exchangeType: "topic",
+    routingKey: "demo.*",
+  });
+
+const ping = event("demo.ping", "v1").of<{ seq: number }>();
+
+await pub.produce(
+  ping({ seq: 1 })
+); // routing key: "demo.ping"
+```
+
+You can always override the publish routing key explicitly:
+
+```ts
+await pub.publish(
+  hello({ msg: "world" }),
+  { routingKey: "custom.key" }
+);
 ```
 
 ---

--- a/docs/features/typed-events.md
+++ b/docs/features/typed-events.md
@@ -225,15 +225,49 @@ export const makeOrderCreated = event("orderCreated", "v1").of<OrderCreated>();
 
 By default, Rabbit Relay publishes with the **event name as the routing key**.
 
-- Topic exchanges support patterns (e.g. `order.*`).
-- Direct exchanges require an exact match.
+```ts
+const makeOrderCreated = event("order.created", "v1").of<OrderCreated>();
 
-You can also set a custom routing key on the exchange:
+await pub.produce(
+  makeOrderCreated({
+    orderId: "O-1",
+    total: 99.5,
+  })
+); // routing key: "order.created"
+```
+
+If `.exchange(...)` is configured with a concrete `routingKey`, Rabbit Relay uses that key when publishing:
 
 ```ts
 await broker.queue("q").exchange("ex", {
   exchangeType: "direct",
   routingKey: "my.custom.key",
+});
+```
+
+For topic wildcard bindings such as `#` or `order.*`, Rabbit Relay treats the value as a binding pattern and continues publishing with the event name.
+
+```ts
+const sub = await broker.queue("orders.q").exchange("orders.ex", {
+  exchangeType: "topic",
+  routingKey: "order.*",
+});
+
+const makeOrderCreated = event("order.created", "v1").of<OrderCreated>();
+
+await sub.produce(
+  makeOrderCreated({
+    orderId: "O-1",
+    total: 99.5,
+  })
+); // routing key: "order.created"
+```
+
+You can always override the publish routing key explicitly:
+
+```ts
+await pub.publish(eventEnvelope, {
+  routingKey: "custom.key",
 });
 ```
 

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -97,7 +97,7 @@ await sub.consume({
 
 ## Publish with the `with()` API
 
-`with()` converts event factories into a small typed publish API.
+`with()` converts event factories into a small typed publish API. Calling a generated method creates the event and publishes it, so it returns a Promise and should be awaited.
 
 ```ts
 const api = pub.with({ scheduleTask });

--- a/lib/publisher.ts
+++ b/lib/publisher.ts
@@ -99,6 +99,29 @@ export function createPublisher(params: {
     );
   };
 
+  const resolvePublishRoutingKey = (
+    evt: EventEnvelope,
+    opts?: PublishOptions
+  ): string => {
+    if (opts?.routingKey) return opts.routingKey;
+
+    const configuredRoutingKey = exchangeConfig.routingKey;
+
+    // exchangeConfig.routingKey is often a binding pattern for consumers.
+    // Do not use topic wildcards as publish routing keys.
+    if (
+      configuredRoutingKey &&
+      configuredRoutingKey !== "#" &&
+      configuredRoutingKey !== "*" &&
+      !configuredRoutingKey.includes("#") &&
+      !configuredRoutingKey.includes("*")
+    ) {
+      return configuredRoutingKey;
+    }
+
+    return evt.name;
+  };
+
   const serializeEvent = (
     event: EventEnvelope,
     opts?: PublishOptions
@@ -139,7 +162,7 @@ export function createPublisher(params: {
     await pluginManager.executeHook("beforeProduce", evt);
 
     const content = serializeEvent(evt, opts);
-    const routingKey = opts?.routingKey ?? evt.name;
+    const routingKey = resolvePublishRoutingKey(evt, opts);
 
     try {
       await safePublish((ch) => {
@@ -183,7 +206,7 @@ export function createPublisher(params: {
     await pluginManager.executeHook("beforeProduce", evt);
 
     const content = serializeEvent(evt, opts);
-    const routingKey = opts?.routingKey ?? evt.name;
+    const routingKey = resolvePublishRoutingKey(evt, opts);
 
     try {
       await safePublish(async (pubCh) => {

--- a/lib/rabbitmqBroker.ts
+++ b/lib/rabbitmqBroker.ts
@@ -404,7 +404,7 @@ export class RabbitMQBroker {
         const augmented = augmentEvents(events, brokerInterface);
 
         return augmented as BrokerInterface<{ [K in keyof U]: ReturnType<U[K]> }> & {
-          [K in keyof U]: (...args: Parameters<U[K]>) => ReturnType<U[K]>;
+          [K in keyof U]: (...args: Parameters<U[K]>) => Promise<void | unknown>;
         };
       },
     };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -289,7 +289,7 @@ export interface BrokerInterface<TEvents extends Record<string, EventEnvelope>> 
   with<U extends Record<string, (...args: any[]) => EventEnvelope>>(
     events: U
   ): BrokerInterface<{ [K in keyof U]: ReturnType<U[K]> }> & {
-    [K in keyof U]: (...args: Parameters<U[K]>) => ReturnType<U[K]>;
+    [K in keyof U]: (...args: Parameters<U[K]>) => Promise<void | unknown>;
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes two public API correctness issues before the stable 1.0.0 release.

## Changes

- Uses a concrete configured exchange routing key when publishing.
- Keeps topic wildcard bindings like `#` and `demo.*` publishing by event name.
- Corrects `.with(events)` generated method return types to `Promise`.

## Validation

- npm run build
- examples/04-plugins publisher/consumer
- examples/01-confirms/dedupe publisher/consumer
- examples/03-dlq publisher/consumer