### PR TITLE
fix(#28: emit message.dropped lifecycle event before silent ack

### DIFF
--- a/docs/features/lifecycle-hooks.md
+++ b/docs/features/lifecycle-hooks.md
@@ -45,6 +45,7 @@ sub.on("consumer.started", (event) => {
 | `broker.closed` | Broker was closed |
 | `handler.completed` | A handler finished (success or error), with duration |
 | `message.dead-lettered` | A message was sent to the dead-letter queue |
+| `message.dropped` | A message was dropped (acked) after retry exhaustion or `onError: "ack"` |
 
 ---
 

--- a/docs/features/opentelemetry.md
+++ b/docs/features/opentelemetry.md
@@ -53,6 +53,7 @@ The adapter listens to:
 | `broker.closed` | Broker shut down |
 | `handler.completed` | Handler finished (success or error) |
 | `message.dead-lettered` | Message sent to dead-letter queue |
+| `message.dropped` | Message dropped (acked) after retry exhaustion or `onError: "ack"` |
 
 ---
 

--- a/lib/consumer.ts
+++ b/lib/consumer.ts
@@ -353,6 +353,14 @@ export function createConsumer(params: {
       return;
     }
 
+    emitLifecycle("message.dropped", {
+      peerName,
+      queue: queueName,
+      exchange: msg.fields.exchange,
+      routingKey: msg.fields.routingKey,
+      eventName: payload?.name ?? "unknown",
+      reason: "retry attempts exhausted, retry.then=ack",
+    }).catch(() => {});
     ch.ack(msg);
   }
 
@@ -482,6 +490,14 @@ export function createConsumer(params: {
       return;
     }
 
+    await emitLifecycle("message.dropped", {
+      peerName,
+      queue: queueName,
+      exchange: msg.fields.exchange,
+      routingKey: msg.fields.routingKey,
+      eventName: payload?.name ?? "unknown",
+      reason: err,
+    });
     ch.ack(msg);
   }
 

--- a/lib/lifecycle.ts
+++ b/lib/lifecycle.ts
@@ -60,6 +60,15 @@ export type LifecycleEventMap = {
     eventName: string;
     reason: unknown;
   };
+
+  "message.dropped": {
+    peerName: string;
+    queue: string;
+    exchange: string;
+    routingKey: string;
+    eventName: string;
+    reason: unknown;
+  };
 };
 
 export type LifecycleEventName = keyof LifecycleEventMap;

--- a/lib/otel.ts
+++ b/lib/otel.ts
@@ -259,6 +259,19 @@ function attributesForEvent<K extends LifecycleEventName>(
       };
     }
 
+    case "message.dropped": {
+      const ev = event as LifecycleEventMap["message.dropped"];
+
+      return {
+        ...base,
+        "rabbit-relay.peer": ev.peerName,
+        "messaging.rabbitmq.queue": ev.queue,
+        "messaging.destination.name": ev.exchange,
+        "messaging.rabbitmq.routing_key": ev.routingKey,
+        "messaging.message.type": ev.eventName,
+      };
+    }
+
     default:
       return base;
   }
@@ -329,6 +342,7 @@ export function attachOpenTelemetry(
   attach("broker.closed");
   attach("handler.completed");
   attach("message.dead-lettered");
+  attach("message.dropped");
 
   return {
     detach(): void {


### PR DESCRIPTION
## Problem

When `retry.then = "ack"` exhausts retry attempts, or when `onError = "ack"` fires directly, the message is acked with **no lifecycle event**. Ops teams monitoring `retry.scheduled` and `message.dead-lettered` see retries happening, then silence — the message just vanishes.

Closes #28

## Fix

Adds a new `message.dropped` lifecycle event, emitted before the ack in both silent-drop paths:

- `applyFinalFailureAction` — retry exhaustion with `retryThen = "ack"`
- `handleFailure` — direct `onError = "ack"`

The event includes: `peerName`, `queue`, `exchange`, `routingKey`, `eventName`, `reason`.

## Changes

- `lib/lifecycle.ts` — added `message.dropped` event type
- `lib/consumer.ts` — emit `message.dropped` before ack in both paths
- `lib/otel.ts` — mapped `message.dropped` to OpenTelemetry spans
- `docs/features/lifecycle-hooks.md` — added event to table
- `docs/features/opentelemetry.md` — added event to table

## Verification

- `npm run build` ✓
- `npm run test:unit` — 95/95 pass ✓