### PR TITLE
fix(#27): emit topology.failed lifecycle event on assert/passive errors

### DIFF
--- a/docs/features/lifecycle-hooks.md
+++ b/docs/features/lifecycle-hooks.md
@@ -38,6 +38,7 @@ sub.on("consumer.started", (event) => {
 |---|---|
 | `reconnect` | Broker reconnected |
 | `topology.asserted` | Exchange/queue/binding topology was asserted |
+| `topology.failed` | Topology assert or passive check failed |
 | `consumer.started` | Consumer started |
 | `consumer.stopped` | Consumer stopped |
 | `publish.failed` | Publish failed after retry attempt |

--- a/docs/features/opentelemetry.md
+++ b/docs/features/opentelemetry.md
@@ -46,6 +46,7 @@ The adapter listens to:
 |---|---|
 | `reconnect` | Broker re-established connection |
 | `topology.asserted` | Exchange, queue, and bindings declared |
+| `topology.failed` | Topology assert or passive check failed |
 | `consumer.started` | Consumer registered on a queue |
 | `consumer.stopped` | Consumer cancelled |
 | `publish.failed` | Publish rejected or errored |

--- a/lib/lifecycle.ts
+++ b/lib/lifecycle.ts
@@ -9,6 +9,13 @@ export type LifecycleEventMap = {
     queue: string;
   };
 
+  "topology.failed": {
+    peerName: string;
+    exchange: string;
+    queue: string;
+    error: unknown;
+  };
+
   "consumer.started": {
     peerName: string;
     queue: string;

--- a/lib/otel.ts
+++ b/lib/otel.ts
@@ -176,6 +176,17 @@ function attributesForEvent<K extends LifecycleEventName>(
       };
     }
 
+    case "topology.failed": {
+      const ev = event as LifecycleEventMap["topology.failed"];
+
+      return {
+        ...base,
+        "rabbit-relay.peer": ev.peerName,
+        "messaging.destination.name": ev.exchange,
+        "messaging.rabbitmq.queue": ev.queue,
+      };
+    }
+
     case "consumer.started": {
       const ev = event as LifecycleEventMap["consumer.started"];
 
@@ -300,6 +311,12 @@ export function attachOpenTelemetry(
         return;
       }
 
+      if (eventName === "topology.failed") {
+        const ev = event as LifecycleEventMap["topology.failed"];
+        finishError(span, ev.error, errorCode);
+        return;
+      }
+
       if (eventName === "retry.scheduled") {
         const ev = event as LifecycleEventMap["retry.scheduled"];
 
@@ -322,6 +339,7 @@ export function attachOpenTelemetry(
 
   attach("reconnect");
   attach("topology.asserted");
+  attach("topology.failed");
   attach("consumer.started");
   attach("consumer.stopped");
   attach("publish.failed");

--- a/lib/rabbitmqBroker.ts
+++ b/lib/rabbitmqBroker.ts
@@ -314,26 +314,46 @@ export class RabbitMQBroker {
       }
 
       if (cfg.topologyMode === "passive") {
-        const result = await this.validatePlan(topologyPlan);
-        const blockingIssues = blockingTopologyIssues(result);
+        try {
+          const result = await this.validatePlan(topologyPlan);
+          const blockingIssues = blockingTopologyIssues(result);
 
-        if (blockingIssues.length > 0) {
-          throw new Error(
-            `[broker] topologyMode='passive' validation failed for exchange '${exchangeName}' and queue '${queueName}': ` +
-              formatTopologyValidationIssues(blockingIssues)
-          );
+          if (blockingIssues.length > 0) {
+            throw new Error(
+              `[broker] topologyMode='passive' validation failed for exchange '${exchangeName}' and queue '${queueName}': ` +
+                formatTopologyValidationIssues(blockingIssues)
+            );
+          }
+        } catch (err) {
+          await this.lifecycle.emit("topology.failed", {
+            peerName: this.peerName,
+            exchange: exchangeName,
+            queue: queueName,
+            error: err,
+          });
+          throw err;
         }
 
         return;
       }
 
-      await assertTopology(channel);
+      try {
+        await assertTopology(channel);
 
-      await this.lifecycle.emit("topology.asserted", {
-        peerName: this.peerName,
-        exchange: exchangeName,
-        queue: queueName,
-      });
+        await this.lifecycle.emit("topology.asserted", {
+          peerName: this.peerName,
+          exchange: exchangeName,
+          queue: queueName,
+        });
+      } catch (err) {
+        await this.lifecycle.emit("topology.failed", {
+          peerName: this.peerName,
+          exchange: exchangeName,
+          queue: queueName,
+          error: err,
+        });
+        throw err;
+      }
     };
 
     if (cfg.topologyMode !== "plan-only") {


### PR DESCRIPTION
## Problem

When `assertQueue`/`assertExchange` fails (e.g. 405 `RESOURCE_LOCKED` on an exclusive queue, 406 `PRECONDITION_FAILED` on mismatched queue arguments), the error escapes as an unhandled Promise rejection and can kill the process. There's a `publish.failed` lifecycle event for publish errors, but **no `topology.failed` event** for topology errors.

Closes #27

## Fix

Adds a new `topology.failed` lifecycle event, emitted before re-throwing in both topology paths:

- **Assert mode:** `assertTopology` failure (exchange/queue/binding assert)
- **Passive mode:** validation blocking issues (missing exchange/queue)

The event includes: `peerName`, `exchange`, `queue`, `error`.

**Behavior preserved:** errors still propagate to the caller (initial setup) and `ReconnectController` (reconnect). The event is additive — ops teams can now observe and react to topology failures without changing existing error handling.

## Changes

- `lib/lifecycle.ts` — added `topology.failed` event type
- `lib/rabbitmqBroker.ts` — wrap `applyTopology` in try/catch, emit event, re-throw
- `lib/otel.ts` — mapped `topology.failed` as an error span
- `docs/features/lifecycle-hooks.md` — added event to table
- `docs/features/opentelemetry.md` — added event to table

## Verification

- `npm run build` ✓
- `npm run test:unit` — 95/95 pass ✓