### PR TITLE
fix(#25): emit topology.restored lifecycle event after reconnect

### DIFF
--- a/docs/features/lifecycle-hooks.md
+++ b/docs/features/lifecycle-hooks.md
@@ -39,6 +39,7 @@ sub.on("consumer.started", (event) => {
 | `reconnect` | Broker reconnected |
 | `topology.asserted` | Exchange/queue/binding topology was asserted |
 | `topology.failed` | Topology assert or passive check failed |
+| `topology.restored` | Topology and consumers restored after reconnect |
 | `consumer.started` | Consumer started |
 | `consumer.stopped` | Consumer stopped |
 | `publish.failed` | Publish failed after retry attempt |

--- a/docs/features/opentelemetry.md
+++ b/docs/features/opentelemetry.md
@@ -47,6 +47,7 @@ The adapter listens to:
 | `reconnect` | Broker re-established connection |
 | `topology.asserted` | Exchange, queue, and bindings declared |
 | `topology.failed` | Topology assert or passive check failed |
+| `topology.restored` | Topology and consumers restored after reconnect |
 | `consumer.started` | Consumer registered on a queue |
 | `consumer.stopped` | Consumer cancelled |
 | `publish.failed` | Publish rejected or errored |

--- a/lib/lifecycle.ts
+++ b/lib/lifecycle.ts
@@ -16,6 +16,12 @@ export type LifecycleEventMap = {
     error: unknown;
   };
 
+  "topology.restored": {
+    peerName: string;
+    exchange: string;
+    queue: string;
+  };
+
   "consumer.started": {
     peerName: string;
     queue: string;

--- a/lib/otel.ts
+++ b/lib/otel.ts
@@ -187,6 +187,17 @@ function attributesForEvent<K extends LifecycleEventName>(
       };
     }
 
+    case "topology.restored": {
+      const ev = event as LifecycleEventMap["topology.restored"];
+
+      return {
+        ...base,
+        "rabbit-relay.peer": ev.peerName,
+        "messaging.destination.name": ev.exchange,
+        "messaging.rabbitmq.queue": ev.queue,
+      };
+    }
+
     case "consumer.started": {
       const ev = event as LifecycleEventMap["consumer.started"];
 
@@ -353,6 +364,7 @@ export function attachOpenTelemetry(
   attach("reconnect");
   attach("topology.asserted");
   attach("topology.failed");
+  attach("topology.restored");
   attach("consumer.started");
   attach("consumer.stopped");
   attach("publish.failed");

--- a/lib/rabbitmqBroker.ts
+++ b/lib/rabbitmqBroker.ts
@@ -401,6 +401,12 @@ export class RabbitMQBroker {
       await applyTopology(ch);
 
       await consumer.resumeOnReconnect(ch);
+
+      await this.lifecycle.emit("topology.restored", {
+        peerName: this.peerName,
+        exchange: exchangeName,
+        queue: queueName,
+      });
     });
 
     const use = (middleware: ConsumeMiddleware): BrokerInterface<TEvents> => {


### PR DESCRIPTION
## Problem

After a broker restart, the `reconnect` lifecycle event fires **before** topology and consumers are re-asserted. If a user's `reconnect` handler immediately tries `withChannel` operations (e.g. `bindQueue`), it fails with "queue does not exist" because the queue hasn't been re-declared yet.

This especially affects exclusive/auto-delete queues that are destroyed on broker restart.

Closes #25

## Fix

Adds a new `topology.restored` lifecycle event, emitted **after** `applyTopology` + `consumer.resumeOnReconnect` complete in the reconnect callback.

The event includes: `peerName`, `exchange`, `queue`.

**Users should listen to `topology.restored` instead of `reconnect` for post-reconnection topology operations.**

## Callback ordering after this fix

```
1. reconnect              ← broker reconnected (topology NOT yet restored)
2. applyTopology          ← exchange/queue/binding re-asserted
3. consumer.resumeOnReconnect  ← consumers resumed
4. topology.restored      ← safe to do withChannel operations now
```

## Changes

- `lib/lifecycle.ts` — added `topology.restored` event type
- `lib/rabbitmqBroker.ts` — emit event after topology + consumer restoration
- `lib/otel.ts` — mapped `topology.restored` to OpenTelemetry spans
- `docs/features/lifecycle-hooks.md` — added event to table
- `docs/features/opentelemetry.md` — added event to table

## Verification

- `npm run build` ✓
- `npm run test:unit` — 95/95 pass ✓