### PR TITLE
fix(#24): add binding option to skip initial queue binding

### DIFF
--- a/docs/features/amqplib-escape-hatch.md
+++ b/docs/features/amqplib-escape-hatch.md
@@ -146,6 +146,28 @@ These options are passed to `channel.consume()`.
 
 ---
 
+## Skipping the initial binding
+
+Set `binding: false` to assert the exchange and queue without creating an
+initial binding. This is useful for apps that manage bindings dynamically at
+runtime via `withChannel()`.
+
+```ts
+const sub = await broker
+  .queue("rooms.q")
+  .exchange("rooms.ex", {
+    exchangeType: "topic",
+    binding: false,
+  });
+
+// Later, bind/unbind dynamically:
+await sub.withChannel(async (ch) => {
+  await ch.bindQueue("rooms.q", "rooms.ex", "room.42");
+});
+```
+
+---
+
 ## Raw channel access
 
 For advanced cases, use `withChannel()`.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -92,6 +92,7 @@ Exchange-level options override broker-level defaults.
 | `routingKey` | Binding routing key | `"#"` |
 | `durable` | Durable exchange/queue declaration | `true` |
 | `publisherConfirms` | Use confirm channel for publishing | `false` |
+| `binding` | Whether to bind queue to exchange during assertion | `true` |
 | `topologyMode` | Assert, passively check, or only plan topology | `"assert"` |
 | `passiveQueue` | Backward-compatible queue-only passive check | `false` |
 | `queueArgs` | RabbitMQ queue arguments | `undefined` |

--- a/lib/rabbitmqBroker.ts
+++ b/lib/rabbitmqBroker.ts
@@ -100,6 +100,7 @@ export class RabbitMQBroker {
       routingKey: config.routingKey ?? "#",
       durable: config.durable ?? true,
       publisherConfirms: config.publisherConfirms ?? false,
+      binding: config.binding ?? true,
       queueArgs: config.queueArgs,
       topologyMode: resolveTopologyMode(config.topologyMode),
       maxMessageBytes: config.maxMessageBytes,

--- a/lib/topology.ts
+++ b/lib/topology.ts
@@ -133,6 +133,7 @@ export function mergeInternalCfg(
     durable: exchangeConfig.durable ?? defaultCfg.durable,
     publisherConfirms:
       exchangeConfig.publisherConfirms ?? defaultCfg.publisherConfirms,
+    binding: exchangeConfig.binding ?? defaultCfg.binding,
     queueArgs: exchangeConfig.queueArgs ?? defaultCfg.queueArgs,
     topologyMode: resolveTopologyMode(
       exchangeConfig.topologyMode ?? defaultCfg.topologyMode
@@ -250,12 +251,14 @@ export function createTopologyPlan(params: {
 
   const bindArgs = mergeBindArguments(cfg.amqp?.bind);
 
-  bindings.push({
-    queue: queueName,
-    exchange: exchangeName,
-    routingKey: cfg.routingKey,
-    arguments: toRecord(bindArgs),
-  });
+  if (cfg.binding !== false) {
+    bindings.push({
+      queue: queueName,
+      exchange: exchangeName,
+      routingKey: cfg.routingKey,
+      arguments: toRecord(bindArgs),
+    });
+  }
 
   return {
     exchanges,
@@ -348,9 +351,11 @@ export function createAssertTopology(params: {
       }
     }
 
-    const bindArgs = mergeBindArguments(cfg.amqp?.bind);
+    if (cfg.binding !== false) {
+      const bindArgs = mergeBindArguments(cfg.amqp?.bind);
 
-    // (Re)bind is idempotent - safe to call even if binding already exists
-    await channel.bindQueue(queueName, exchangeName, cfg.routingKey, bindArgs);
+      // (Re)bind is idempotent - safe to call even if binding already exists
+      await channel.bindQueue(queueName, exchangeName, cfg.routingKey, bindArgs);
+    }
   };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -74,6 +74,17 @@ export interface ExchangeConfig {
 
   publisherConfirms?: boolean;
 
+  /**
+   * Whether to bind the queue to the exchange during topology assertion.
+   *
+   * Set to `false` to assert the exchange and queue without creating an
+   * initial binding. Useful for apps that manage bindings dynamically at
+   * runtime via `withChannel()`.
+   *
+   * Default: `true`
+   */
+  binding?: boolean;
+
   queueArgs?: Options.AssertQueue["arguments"];
 
   /**
@@ -351,6 +362,7 @@ export type InternalCfg = {
   routingKey: string;
   durable: boolean;
   publisherConfirms: boolean;
+  binding: boolean;
   queueArgs?: Options.AssertQueue["arguments"];
   topologyMode: TopologyMode;
   maxMessageBytes?: number;


### PR DESCRIPTION
## Problem

When `exchange()` is called without a `routingKey`, the queue is silently bound to `#` (match everything). That's easy to miss and wrong for dynamic-topology apps that manage bindings at runtime via `withChannel()`.

The only workaround was to assert a dummy pattern (e.g. `room.__unbound__.#`) at setup, then bind/unbind real patterns via `withChannel`.

Closes #24

## Fix

Adds a `binding` option (default: `true`) to `ExchangeConfig`. When set to `false`:

- The exchange and queue are still asserted
- The initial `bindQueue` call is skipped
- The topology plan omits the binding entry

### Usage

```ts
const sub = await broker
  .queue("rooms.q")
  .exchange("rooms.ex", {
    exchangeType: "topic",
    binding: false,
  });

// Bind/unbind dynamically at runtime:
await sub.withChannel(async (ch) => {
  await ch.bindQueue("rooms.q", "rooms.ex", "room.42");
});
```

## Changes

- `lib/types.ts` — added `binding` to `ExchangeConfig` and `InternalCfg`
- `lib/topology.ts` — skip `bindQueue` and plan binding entry when `binding === false`
- `lib/rabbitmqBroker.ts` — default `binding: true` in constructor
- `docs/guide/configuration.md` — added `binding` to options table
- `docs/features/amqplib-escape-hatch.md` — added "Skipping the initial binding" section with example

## Verification

- `npm run build` ✓
- `npm run test:unit` — 95/95 pass ✓

## Backward compatibility

- Default is `true` — existing behavior unchanged
- `binding: false` is opt-in